### PR TITLE
fix(qis-compiler): build source wheels in release mode

### DIFF
--- a/qis-compiler/pyproject.toml
+++ b/qis-compiler/pyproject.toml
@@ -45,7 +45,8 @@ version = "0.4.2" # updated by release-please
 repository = "https://github.com/quantinuum/tket2/tree/main/qis-compiler"
 
 [tool.maturin]
-profile = "dev"
+# Keep the profile unset: wheel builds default to release, while `maturin develop`
+# defaults to dev for fast local iteration.
 python-source = "python"
 manifest-path = "Cargo.toml"
 features = ["py"]


### PR DESCRIPTION
## Summary

- remove the project-wide `profile = "dev"` override from the QIS compiler's Maturin configuration
- document why the profile is intentionally left unset
- allow PEP 517 source-wheel builds to use Maturin's release default while retaining debug builds for ordinary `maturin develop` use

## Root cause

The project-level Maturin profile applied to every build frontend, not only local development. Published wheels were unaffected because cibuildwheel explicitly passes `--profile=release`, but downstream installations from a Git revision used the committed `dev` override and produced an unoptimized `selene_hugr_qis_compiler` PyO3 extension.

This made source installs behave differently from published wheels and contaminated downstream compiler performance measurements.

Closes #1929.

## Validation

- parsed `qis-compiler/pyproject.toml` with `tomllib` and verified that no project-wide Maturin profile remains
- checked Maturin 1.14.1's `develop` and PEP 517 command behavior
- `cargo fmt --all -- --check`
- `git diff --check`

The existing QIS wheel workflow is triggered by this `pyproject.toml` change and will build wheels on all supported CI platforms.
