### PR TITLE
ci: Alternative to dependabot `versioning-strategy: widen` with uv

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -52,7 +52,19 @@ updates:
       minor:
         update-types: ["minor"]
       # Major updates still generate individual PRs
-    versioning-strategy: "widen"
+
+    # Do not bump the minimal version of dependencies, only widen the upper bound.
+    #
+    # Bumping the minimum can be a breaking change for downstream python users,
+    # as they may break their dependency resolution and prevent them from updating.
+    #
+    # The dependabot documentation indicates this can be done by setting versioning-strategy to "widen",
+    # but this returned errors saying that the value is invalid.
+    # (https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#versioning-strategy--)
+    #
+    # The uv versioning-strategy issue mentions "widen-ranges" instead
+    # see https://github.com/dependabot/dependabot-core/issues/12162#issuecomment-3898828918
+    versioning-strategy: "widen-ranges"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Previously we set the strategy to `widen` as per the [dependabot documentation](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#versioning-strategy--), but dependabot [complains](https://github.com/Quantinuum/tket2/runs/95456207467) saying it's an invalid option -.-
```
The property '#/updates/1/versioning-strategy' value "widen" did not match one of the following values: lockfile-only, auto, increase, increase-if-necessary
```

The uv support issue (https://github.com/dependabot/dependabot-core/issues/12162#issuecomment-3898828918) mentions `widen-ranges` instead. Let's see if that works.

This is mostly just a test, I doubt it will actually work.
Here's another issue discussing `widen` support: https://github.com/dependabot/dependabot-core/issues/15290

Edit: It did not work, we had to fallback to `lockfile-only`.