### PR TITLE
ci: Fix dependabot versioning-strategy, again

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -53,18 +53,19 @@ updates:
         update-types: ["minor"]
       # Major updates still generate individual PRs
 
-    # Do not bump the minimal version of dependencies, only widen the upper bound.
+    # Do not bump the minimal version of dependencies.
     #
     # Bumping the minimum can be a breaking change for downstream python users,
     # as they may break their dependency resolution and prevent them from updating.
     #
+    # Ideally we'd widen the upper bound.
     # The dependabot documentation indicates this can be done by setting versioning-strategy to "widen",
     # but this returned errors saying that the value is invalid.
     # (https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#versioning-strategy--)
     #
-    # The uv versioning-strategy issue mentions "widen-ranges" instead
-    # see https://github.com/dependabot/dependabot-core/issues/12162#issuecomment-3898828918
-    versioning-strategy: "widen-ranges"
+    # See the uv versioning-strategy issue:
+    # <https://github.com/dependabot/dependabot-core/issues/15290>
+    versioning-strategy: "lockfile-only"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
The experiment from #1932 did not work.
So we fall back to the least bad option: only updating the `uv.lock` file, and ignoring newer versions that require modifying the range.