### PR TITLE
feat!: Rename Sol ___lazy_measure to ___future_measure

### DIFF
--- a/qis-compiler/python/tests/snapshots/test_basic_generation/test_llvm/sol-aarch64-apple-darwin-flip_some/flip_some_aarch64-apple-darwin_sol
+++ b/qis-compiler/python/tests/snapshots/test_basic_generation/test_llvm/sol-aarch64-apple-darwin-flip_some/flip_some_aarch64-apple-darwin_sol
@@ -53,31 +53,31 @@ cond_40_case_0.i44:                               ; preds = %__hugr__.__tk2_sol_
 
 __hugr__.__tk2_sol_qalloc.36.exit45:              ; preds = %__hugr__.__tk2_sol_qalloc.36.exit41
   tail call void @___reset(i64 %qalloc.i42), !dbg !13
-  %___lazy_measure = tail call i64 @___lazy_measure(i64 %qalloc.i, i64 0), !dbg !14
+  %___future_measure = tail call i64 @___future_measure(i64 %qalloc.i, i64 0), !dbg !14
   tail call void @___qfree(i64 %qalloc.i), !dbg !14
   tail call void @___rp(i64 %qalloc.i42, double 0x400921FB54442D18, double 0.000000e+00), !dbg !15
-  %read_bool = tail call i1 @___read_future_bool(i64 %___lazy_measure), !dbg !14
-  tail call void @___dec_future_refcount(i64 %___lazy_measure), !dbg !14
+  %read_bool = tail call i1 @___read_future_bool(i64 %___future_measure), !dbg !14
+  tail call void @___dec_future_refcount(i64 %___future_measure), !dbg !14
   tail call void @print_bool(ptr nonnull @res_c0.7C14CD6E.0, i64 12, i1 %read_bool), !dbg !16
-  %___lazy_measure9 = tail call i64 @___lazy_measure(i64 %qalloc.i34, i64 0), !dbg !17
+  %___future_measure9 = tail call i64 @___future_measure(i64 %qalloc.i34, i64 0), !dbg !17
   tail call void @___qfree(i64 %qalloc.i34), !dbg !17
-  %read_bool11 = tail call i1 @___read_future_bool(i64 %___lazy_measure9), !dbg !17
-  tail call void @___dec_future_refcount(i64 %___lazy_measure9), !dbg !17
+  %read_bool11 = tail call i1 @___read_future_bool(i64 %___future_measure9), !dbg !17
+  tail call void @___dec_future_refcount(i64 %___future_measure9), !dbg !17
   tail call void @print_bool(ptr nonnull @res_c1.1F7A6571.0, i64 12, i1 %read_bool11), !dbg !18
-  %___lazy_measure17 = tail call i64 @___lazy_measure(i64 %qalloc.i38, i64 0), !dbg !19
+  %___future_measure17 = tail call i64 @___future_measure(i64 %qalloc.i38, i64 0), !dbg !19
   tail call void @___qfree(i64 %qalloc.i38), !dbg !19
-  %read_bool19 = tail call i1 @___read_future_bool(i64 %___lazy_measure17), !dbg !19
-  tail call void @___dec_future_refcount(i64 %___lazy_measure17), !dbg !19
+  %read_bool19 = tail call i1 @___read_future_bool(i64 %___future_measure17), !dbg !19
+  tail call void @___dec_future_refcount(i64 %___future_measure17), !dbg !19
   tail call void @print_bool(ptr nonnull @res_c2.60825383.0, i64 12, i1 %read_bool19), !dbg !20
-  %___lazy_measure25 = tail call i64 @___lazy_measure(i64 %qalloc.i42, i64 0), !dbg !21
+  %___future_measure25 = tail call i64 @___future_measure(i64 %qalloc.i42, i64 0), !dbg !21
   tail call void @___qfree(i64 %qalloc.i42), !dbg !21
-  %read_bool27 = tail call i1 @___read_future_bool(i64 %___lazy_measure25), !dbg !21
-  tail call void @___dec_future_refcount(i64 %___lazy_measure25), !dbg !21
+  %read_bool27 = tail call i1 @___read_future_bool(i64 %___future_measure25), !dbg !21
+  tail call void @___dec_future_refcount(i64 %___future_measure25), !dbg !21
   tail call void @print_bool(ptr nonnull @res_c3.B223E16D.0, i64 12, i1 %read_bool27), !dbg !22
   ret void
 }
 
-declare i64 @___lazy_measure(i64, i64) local_unnamed_addr
+declare i64 @___future_measure(i64, i64) local_unnamed_addr
 
 declare void @___qfree(i64) local_unnamed_addr
 

--- a/qis-compiler/python/tests/snapshots/test_basic_generation/test_llvm/sol-aarch64-apple-darwin-measure_qb_array/measure_qb_array_aarch64-apple-darwin_sol
+++ b/qis-compiler/python/tests/snapshots/test_basic_generation/test_llvm/sol-aarch64-apple-darwin-measure_qb_array/measure_qb_array_aarch64-apple-darwin_sol
@@ -361,7 +361,7 @@ __barray_check_bounds.exit.i:                     ; preds = %__barray_check_boun
   store i64 %103, ptr %97, align 4, !dbg !58
   %104 = getelementptr inbounds i64, ptr %.fca.0.extract62.i179.i, i64 %95, !dbg !57
   %105 = load i64, ptr %104, align 4, !dbg !57
-  %___lazy_measure.i = tail call i64 @___lazy_measure(i64 %105, i64 0), !dbg !60
+  %___future_measure.i = tail call i64 @___future_measure(i64 %105, i64 0), !dbg !60
   tail call void @___qfree(i64 %105), !dbg !60
   %106 = load i64, ptr %71, align 4
   %107 = lshr i64 %106, %"200_0.sroa.15.0178.i"
@@ -378,7 +378,7 @@ loop_body.i:                                      ; preds = %__barray_check_boun
   %111 = xor i64 %106, %110
   store i64 %111, ptr %71, align 4
   %112 = getelementptr inbounds nuw i64, ptr %70, i64 %"200_0.sroa.15.0178.i"
-  store i64 %___lazy_measure.i, ptr %112, align 4
+  store i64 %___future_measure.i, ptr %112, align 4
   %113 = extractvalue { { ptr, ptr, i64 }, i64 } %.pn159177.i, 0
   %.fca.0.extract62.i.i = extractvalue { ptr, ptr, i64 } %113, 0
   %.fca.1.extract63.i.i = extractvalue { ptr, ptr, i64 } %113, 1
@@ -705,7 +705,7 @@ declare i1 @___read_future_bool(i64) local_unnamed_addr
 
 declare void @___dec_future_refcount(i64) local_unnamed_addr
 
-declare i64 @___lazy_measure(i64, i64) local_unnamed_addr
+declare i64 @___future_measure(i64, i64) local_unnamed_addr
 
 declare void @___qfree(i64) local_unnamed_addr
 

--- a/qis-compiler/python/tests/snapshots/test_basic_generation/test_llvm/sol-aarch64-apple-darwin-no_results/no_results_aarch64-apple-darwin_sol
+++ b/qis-compiler/python/tests/snapshots/test_basic_generation/test_llvm/sol-aarch64-apple-darwin-no_results/no_results_aarch64-apple-darwin_sol
@@ -19,14 +19,14 @@ __hugr__.__tk2_sol_qalloc.15.exit:                ; preds = %alloca_block
   tail call void @___reset(i64 %qalloc.i), !dbg !8
   tail call void @___rp(i64 %qalloc.i, double 0x3FF921FB54442D18, double 0xBFF921FB54442D18), !dbg !9
   tail call void @___rz(i64 %qalloc.i, double 0x400921FB54442D18), !dbg !9
-  %___lazy_measure = tail call i64 @___lazy_measure(i64 %qalloc.i, i64 0), !dbg !10
+  %___future_measure = tail call i64 @___future_measure(i64 %qalloc.i, i64 0), !dbg !10
   tail call void @___qfree(i64 %qalloc.i), !dbg !10
-  %read_bool = tail call i1 @___read_future_bool(i64 %___lazy_measure), !dbg !10
-  tail call void @___dec_future_refcount(i64 %___lazy_measure), !dbg !10
+  %read_bool = tail call i1 @___read_future_bool(i64 %___future_measure), !dbg !10
+  tail call void @___dec_future_refcount(i64 %___future_measure), !dbg !10
   ret void
 }
 
-declare i64 @___lazy_measure(i64, i64) local_unnamed_addr
+declare i64 @___future_measure(i64, i64) local_unnamed_addr
 
 declare void @___qfree(i64) local_unnamed_addr
 

--- a/qis-compiler/python/tests/snapshots/test_basic_generation/test_llvm/sol-aarch64-apple-darwin-postselect_exit/postselect_exit_aarch64-apple-darwin_sol
+++ b/qis-compiler/python/tests/snapshots/test_basic_generation/test_llvm/sol-aarch64-apple-darwin-postselect_exit/postselect_exit_aarch64-apple-darwin_sol
@@ -21,10 +21,10 @@ __hugr__.__tk2_sol_qalloc.40.exit:                ; preds = %alloca_block
   tail call void @___reset(i64 %qalloc.i), !dbg !8
   tail call void @___rp(i64 %qalloc.i, double 0x3FF921FB54442D18, double 0xBFF921FB54442D18), !dbg !9
   tail call void @___rz(i64 %qalloc.i, double 0x400921FB54442D18), !dbg !9
-  %___lazy_measure = tail call i64 @___lazy_measure(i64 %qalloc.i, i64 0), !dbg !10
+  %___future_measure = tail call i64 @___future_measure(i64 %qalloc.i, i64 0), !dbg !10
   tail call void @___qfree(i64 %qalloc.i), !dbg !10
-  %read_bool = tail call i1 @___read_future_bool(i64 %___lazy_measure), !dbg !10
-  tail call void @___dec_future_refcount(i64 %___lazy_measure), !dbg !10
+  %read_bool = tail call i1 @___read_future_bool(i64 %___future_measure), !dbg !10
+  tail call void @___dec_future_refcount(i64 %___future_measure), !dbg !10
   br i1 %read_bool, label %1, label %0
 
 0:                                                ; preds = %__hugr__.__tk2_sol_qalloc.40.exit
@@ -36,7 +36,7 @@ __hugr__.__tk2_sol_qalloc.40.exit:                ; preds = %alloca_block
   unreachable
 }
 
-declare i64 @___lazy_measure(i64, i64) local_unnamed_addr
+declare i64 @___future_measure(i64, i64) local_unnamed_addr
 
 declare void @___qfree(i64) local_unnamed_addr
 

--- a/qis-compiler/python/tests/snapshots/test_basic_generation/test_llvm/sol-aarch64-apple-darwin-postselect_panic/postselect_panic_aarch64-apple-darwin_sol
+++ b/qis-compiler/python/tests/snapshots/test_basic_generation/test_llvm/sol-aarch64-apple-darwin-postselect_panic/postselect_panic_aarch64-apple-darwin_sol
@@ -21,10 +21,10 @@ __hugr__.__tk2_sol_qalloc.38.exit:                ; preds = %alloca_block
   tail call void @___reset(i64 %qalloc.i), !dbg !8
   tail call void @___rp(i64 %qalloc.i, double 0x3FF921FB54442D18, double 0xBFF921FB54442D18), !dbg !9
   tail call void @___rz(i64 %qalloc.i, double 0x400921FB54442D18), !dbg !9
-  %___lazy_measure = tail call i64 @___lazy_measure(i64 %qalloc.i, i64 0), !dbg !10
+  %___future_measure = tail call i64 @___future_measure(i64 %qalloc.i, i64 0), !dbg !10
   tail call void @___qfree(i64 %qalloc.i), !dbg !10
-  %read_bool = tail call i1 @___read_future_bool(i64 %___lazy_measure), !dbg !10
-  tail call void @___dec_future_refcount(i64 %___lazy_measure), !dbg !10
+  %read_bool = tail call i1 @___read_future_bool(i64 %___future_measure), !dbg !10
+  tail call void @___dec_future_refcount(i64 %___future_measure), !dbg !10
   br i1 %read_bool, label %1, label %0
 
 0:                                                ; preds = %__hugr__.__tk2_sol_qalloc.38.exit
@@ -36,7 +36,7 @@ __hugr__.__tk2_sol_qalloc.38.exit:                ; preds = %alloca_block
   unreachable
 }
 
-declare i64 @___lazy_measure(i64, i64) local_unnamed_addr
+declare i64 @___future_measure(i64, i64) local_unnamed_addr
 
 declare void @___qfree(i64) local_unnamed_addr
 

--- a/qis-compiler/python/tests/snapshots/test_basic_generation/test_llvm/sol-aarch64-apple-darwin-rus/rus_aarch64-apple-darwin_sol
+++ b/qis-compiler/python/tests/snapshots/test_basic_generation/test_llvm/sol-aarch64-apple-darwin-rus/rus_aarch64-apple-darwin_sol
@@ -50,10 +50,10 @@ __hugr__.__tk2_sol_qalloc.94.exit94.i:            ; preds = %__hugr__.__tk2_sol_
   tail call void @___rp(i64 %qalloc.i91.i, double 0xBFF921FB54442D18, double 0x3FF921FB54442D18), !dbg !19
   tail call void @___rz(i64 %qalloc.i91.i, double 0xBFF921FB54442D18), !dbg !19
   tail call void @___rz(i64 %qalloc.i100.i, double 0x3FE921FB54442D18), !dbg !20
-  %___lazy_measure.i = tail call i64 @___lazy_measure(i64 %qalloc.i100.i, i64 0), !dbg !21
+  %___future_measure.i = tail call i64 @___future_measure(i64 %qalloc.i100.i, i64 0), !dbg !21
   tail call void @___qfree(i64 %qalloc.i100.i), !dbg !21
-  %read_bool.i.i = tail call i1 @___read_future_bool(i64 %___lazy_measure.i), !dbg !22
-  tail call void @___dec_future_refcount(i64 %___lazy_measure.i), !dbg !22
+  %read_bool.i.i = tail call i1 @___read_future_bool(i64 %___future_measure.i), !dbg !22
+  tail call void @___dec_future_refcount(i64 %___future_measure.i), !dbg !22
   br i1 %read_bool.i.i, label %1, label %0
 
 0:                                                ; preds = %__hugr__.__tk2_sol_qalloc.94.exit94.i
@@ -74,10 +74,10 @@ __hugr__.__tk2_sol_qalloc.94.exit94.i:            ; preds = %__hugr__.__tk2_sol_
   tail call void @___rp(i64 %qalloc.i, double 0xBFF921FB54442D18, double 0x3FF921FB54442D18), !dbg !32
   tail call void @___rz(i64 %qalloc.i, double 0xBFF921FB54442D18), !dbg !32
   tail call void @___rz(i64 %qalloc.i91.i, double 0x3FE921FB54442D18), !dbg !33
-  %___lazy_measure52.i = tail call i64 @___lazy_measure(i64 %qalloc.i91.i, i64 0), !dbg !34
+  %___future_measure52.i = tail call i64 @___future_measure(i64 %qalloc.i91.i, i64 0), !dbg !34
   tail call void @___qfree(i64 %qalloc.i91.i), !dbg !34
-  %read_bool.i97.i = tail call i1 @___read_future_bool(i64 %___lazy_measure52.i), !dbg !35
-  tail call void @___dec_future_refcount(i64 %___lazy_measure52.i), !dbg !35
+  %read_bool.i97.i = tail call i1 @___read_future_bool(i64 %___future_measure52.i), !dbg !35
+  tail call void @___dec_future_refcount(i64 %___future_measure52.i), !dbg !35
   br i1 %read_bool.i97.i, label %"__hugr__.__main__.rus.<locals>.rus.17.exit", label %2
 
 2:                                                ; preds = %1
@@ -85,15 +85,15 @@ __hugr__.__tk2_sol_qalloc.94.exit94.i:            ; preds = %__hugr__.__tk2_sol_
   br label %.backedge.i
 
 "__hugr__.__main__.rus.<locals>.rus.17.exit":     ; preds = %1
-  %___lazy_measure = tail call i64 @___lazy_measure(i64 %qalloc.i, i64 0), !dbg !38
+  %___future_measure = tail call i64 @___future_measure(i64 %qalloc.i, i64 0), !dbg !38
   tail call void @___qfree(i64 %qalloc.i), !dbg !38
-  %read_bool = tail call i1 @___read_future_bool(i64 %___lazy_measure), !dbg !38
-  tail call void @___dec_future_refcount(i64 %___lazy_measure), !dbg !38
+  %read_bool = tail call i1 @___read_future_bool(i64 %___future_measure), !dbg !38
+  tail call void @___dec_future_refcount(i64 %___future_measure), !dbg !38
   tail call void @print_bool(ptr nonnull @res_result.457DE32D.0, i64 16, i1 %read_bool), !dbg !39
   ret void
 }
 
-declare i64 @___lazy_measure(i64, i64) local_unnamed_addr
+declare i64 @___future_measure(i64, i64) local_unnamed_addr
 
 declare void @___qfree(i64) local_unnamed_addr
 

--- a/qis-compiler/python/tests/snapshots/test_basic_generation/test_llvm/sol-aarch64-apple-darwin-simple_modifier/simple_modifier_aarch64-apple-darwin_sol
+++ b/qis-compiler/python/tests/snapshots/test_basic_generation/test_llvm/sol-aarch64-apple-darwin-simple_modifier/simple_modifier_aarch64-apple-darwin_sol
@@ -60,15 +60,15 @@ __hugr__.__tk2_sol_qalloc.39.exit38:              ; preds = %__barray_check_none
   %7 = tail call ptr @heap_alloc(i64 8)
   store i64 0, ptr %7, align 1
   %8 = load i64, ptr %6, align 4
-  %___lazy_measure = tail call i64 @___lazy_measure(i64 %8, i64 0), !dbg !11
+  %___future_measure = tail call i64 @___future_measure(i64 %8, i64 0), !dbg !11
   tail call void @___qfree(i64 %8), !dbg !11
-  %read_bool = tail call i1 @___read_future_bool(i64 %___lazy_measure), !dbg !11
-  tail call void @___dec_future_refcount(i64 %___lazy_measure), !dbg !11
+  %read_bool = tail call i1 @___read_future_bool(i64 %___future_measure), !dbg !11
+  tail call void @___dec_future_refcount(i64 %___future_measure), !dbg !11
   tail call void @print_bool(ptr nonnull @res_c0.7C14CD6E.0, i64 12, i1 %read_bool), !dbg !12
-  %___lazy_measure19 = tail call i64 @___lazy_measure(i64 %qalloc.i35, i64 0), !dbg !13
+  %___future_measure19 = tail call i64 @___future_measure(i64 %qalloc.i35, i64 0), !dbg !13
   tail call void @___qfree(i64 %qalloc.i35), !dbg !13
-  %read_bool21 = tail call i1 @___read_future_bool(i64 %___lazy_measure19), !dbg !13
-  tail call void @___dec_future_refcount(i64 %___lazy_measure19), !dbg !13
+  %read_bool21 = tail call i1 @___read_future_bool(i64 %___future_measure19), !dbg !13
+  tail call void @___dec_future_refcount(i64 %___future_measure19), !dbg !13
   tail call void @print_bool(ptr nonnull @res_c1.1F7A6571.0, i64 12, i1 %read_bool21), !dbg !14
   ret void
 }
@@ -78,7 +78,7 @@ declare ptr @heap_alloc(i64) local_unnamed_addr
 ; Function Attrs: noreturn
 declare void @panic(i32, ptr) local_unnamed_addr #0
 
-declare i64 @___lazy_measure(i64, i64) local_unnamed_addr
+declare i64 @___future_measure(i64, i64) local_unnamed_addr
 
 declare void @___qfree(i64) local_unnamed_addr
 

--- a/qis-compiler/python/tests/snapshots/test_basic_generation/test_llvm/sol-x86_64-apple-darwin-flip_some/flip_some_x86_64-apple-darwin_sol
+++ b/qis-compiler/python/tests/snapshots/test_basic_generation/test_llvm/sol-x86_64-apple-darwin-flip_some/flip_some_x86_64-apple-darwin_sol
@@ -53,31 +53,31 @@ cond_40_case_0.i44:                               ; preds = %__hugr__.__tk2_sol_
 
 __hugr__.__tk2_sol_qalloc.36.exit45:              ; preds = %__hugr__.__tk2_sol_qalloc.36.exit41
   tail call void @___reset(i64 %qalloc.i42), !dbg !13
-  %___lazy_measure = tail call i64 @___lazy_measure(i64 %qalloc.i, i64 0), !dbg !14
+  %___future_measure = tail call i64 @___future_measure(i64 %qalloc.i, i64 0), !dbg !14
   tail call void @___qfree(i64 %qalloc.i), !dbg !14
   tail call void @___rp(i64 %qalloc.i42, double 0x400921FB54442D18, double 0.000000e+00), !dbg !15
-  %read_bool = tail call i1 @___read_future_bool(i64 %___lazy_measure), !dbg !14
-  tail call void @___dec_future_refcount(i64 %___lazy_measure), !dbg !14
+  %read_bool = tail call i1 @___read_future_bool(i64 %___future_measure), !dbg !14
+  tail call void @___dec_future_refcount(i64 %___future_measure), !dbg !14
   tail call void @print_bool(ptr nonnull @res_c0.7C14CD6E.0, i64 12, i1 %read_bool), !dbg !16
-  %___lazy_measure9 = tail call i64 @___lazy_measure(i64 %qalloc.i34, i64 0), !dbg !17
+  %___future_measure9 = tail call i64 @___future_measure(i64 %qalloc.i34, i64 0), !dbg !17
   tail call void @___qfree(i64 %qalloc.i34), !dbg !17
-  %read_bool11 = tail call i1 @___read_future_bool(i64 %___lazy_measure9), !dbg !17
-  tail call void @___dec_future_refcount(i64 %___lazy_measure9), !dbg !17
+  %read_bool11 = tail call i1 @___read_future_bool(i64 %___future_measure9), !dbg !17
+  tail call void @___dec_future_refcount(i64 %___future_measure9), !dbg !17
   tail call void @print_bool(ptr nonnull @res_c1.1F7A6571.0, i64 12, i1 %read_bool11), !dbg !18
-  %___lazy_measure17 = tail call i64 @___lazy_measure(i64 %qalloc.i38, i64 0), !dbg !19
+  %___future_measure17 = tail call i64 @___future_measure(i64 %qalloc.i38, i64 0), !dbg !19
   tail call void @___qfree(i64 %qalloc.i38), !dbg !19
-  %read_bool19 = tail call i1 @___read_future_bool(i64 %___lazy_measure17), !dbg !19
-  tail call void @___dec_future_refcount(i64 %___lazy_measure17), !dbg !19
+  %read_bool19 = tail call i1 @___read_future_bool(i64 %___future_measure17), !dbg !19
+  tail call void @___dec_future_refcount(i64 %___future_measure17), !dbg !19
   tail call void @print_bool(ptr nonnull @res_c2.60825383.0, i64 12, i1 %read_bool19), !dbg !20
-  %___lazy_measure25 = tail call i64 @___lazy_measure(i64 %qalloc.i42, i64 0), !dbg !21
+  %___future_measure25 = tail call i64 @___future_measure(i64 %qalloc.i42, i64 0), !dbg !21
   tail call void @___qfree(i64 %qalloc.i42), !dbg !21
-  %read_bool27 = tail call i1 @___read_future_bool(i64 %___lazy_measure25), !dbg !21
-  tail call void @___dec_future_refcount(i64 %___lazy_measure25), !dbg !21
+  %read_bool27 = tail call i1 @___read_future_bool(i64 %___future_measure25), !dbg !21
+  tail call void @___dec_future_refcount(i64 %___future_measure25), !dbg !21
   tail call void @print_bool(ptr nonnull @res_c3.B223E16D.0, i64 12, i1 %read_bool27), !dbg !22
   ret void
 }
 
-declare i64 @___lazy_measure(i64, i64) local_unnamed_addr
+declare i64 @___future_measure(i64, i64) local_unnamed_addr
 
 declare void @___qfree(i64) local_unnamed_addr
 

--- a/qis-compiler/python/tests/snapshots/test_basic_generation/test_llvm/sol-x86_64-apple-darwin-measure_qb_array/measure_qb_array_x86_64-apple-darwin_sol
+++ b/qis-compiler/python/tests/snapshots/test_basic_generation/test_llvm/sol-x86_64-apple-darwin-measure_qb_array/measure_qb_array_x86_64-apple-darwin_sol
@@ -364,7 +364,7 @@ __barray_check_bounds.exit.i:                     ; preds = %__barray_check_boun
   store i64 %106, ptr %100, align 4, !dbg !58
   %107 = getelementptr inbounds i64, ptr %.fca.0.extract62.i179.i, i64 %98, !dbg !57
   %108 = load i64, ptr %107, align 4, !dbg !57
-  %___lazy_measure.i = tail call i64 @___lazy_measure(i64 %108, i64 0), !dbg !60
+  %___future_measure.i = tail call i64 @___future_measure(i64 %108, i64 0), !dbg !60
   tail call void @___qfree(i64 %108), !dbg !60
   %109 = load i64, ptr %74, align 4
   %110 = lshr i64 %109, %"200_0.sroa.15.0178.i"
@@ -381,7 +381,7 @@ loop_body.i:                                      ; preds = %__barray_check_boun
   %114 = xor i64 %109, %113
   store i64 %114, ptr %74, align 4
   %115 = getelementptr inbounds nuw i64, ptr %73, i64 %"200_0.sroa.15.0178.i"
-  store i64 %___lazy_measure.i, ptr %115, align 4
+  store i64 %___future_measure.i, ptr %115, align 4
   %116 = extractvalue { { ptr, ptr, i64 }, i64 } %.pn159177.i, 0
   %.fca.0.extract62.i.i = extractvalue { ptr, ptr, i64 } %116, 0
   %.fca.1.extract63.i.i = extractvalue { ptr, ptr, i64 } %116, 1
@@ -554,7 +554,7 @@ declare i1 @___read_future_bool(i64) local_unnamed_addr
 
 declare void @___dec_future_refcount(i64) local_unnamed_addr
 
-declare i64 @___lazy_measure(i64, i64) local_unnamed_addr
+declare i64 @___future_measure(i64, i64) local_unnamed_addr
 
 declare void @___qfree(i64) local_unnamed_addr
 

--- a/qis-compiler/python/tests/snapshots/test_basic_generation/test_llvm/sol-x86_64-apple-darwin-no_results/no_results_x86_64-apple-darwin_sol
+++ b/qis-compiler/python/tests/snapshots/test_basic_generation/test_llvm/sol-x86_64-apple-darwin-no_results/no_results_x86_64-apple-darwin_sol
@@ -19,14 +19,14 @@ __hugr__.__tk2_sol_qalloc.15.exit:                ; preds = %alloca_block
   tail call void @___reset(i64 %qalloc.i), !dbg !8
   tail call void @___rp(i64 %qalloc.i, double 0x3FF921FB54442D18, double 0xBFF921FB54442D18), !dbg !9
   tail call void @___rz(i64 %qalloc.i, double 0x400921FB54442D18), !dbg !9
-  %___lazy_measure = tail call i64 @___lazy_measure(i64 %qalloc.i, i64 0), !dbg !10
+  %___future_measure = tail call i64 @___future_measure(i64 %qalloc.i, i64 0), !dbg !10
   tail call void @___qfree(i64 %qalloc.i), !dbg !10
-  %read_bool = tail call i1 @___read_future_bool(i64 %___lazy_measure), !dbg !10
-  tail call void @___dec_future_refcount(i64 %___lazy_measure), !dbg !10
+  %read_bool = tail call i1 @___read_future_bool(i64 %___future_measure), !dbg !10
+  tail call void @___dec_future_refcount(i64 %___future_measure), !dbg !10
   ret void
 }
 
-declare i64 @___lazy_measure(i64, i64) local_unnamed_addr
+declare i64 @___future_measure(i64, i64) local_unnamed_addr
 
 declare void @___qfree(i64) local_unnamed_addr
 

--- a/qis-compiler/python/tests/snapshots/test_basic_generation/test_llvm/sol-x86_64-apple-darwin-postselect_exit/postselect_exit_x86_64-apple-darwin_sol
+++ b/qis-compiler/python/tests/snapshots/test_basic_generation/test_llvm/sol-x86_64-apple-darwin-postselect_exit/postselect_exit_x86_64-apple-darwin_sol
@@ -21,10 +21,10 @@ __hugr__.__tk2_sol_qalloc.40.exit:                ; preds = %alloca_block
   tail call void @___reset(i64 %qalloc.i), !dbg !8
   tail call void @___rp(i64 %qalloc.i, double 0x3FF921FB54442D18, double 0xBFF921FB54442D18), !dbg !9
   tail call void @___rz(i64 %qalloc.i, double 0x400921FB54442D18), !dbg !9
-  %___lazy_measure = tail call i64 @___lazy_measure(i64 %qalloc.i, i64 0), !dbg !10
+  %___future_measure = tail call i64 @___future_measure(i64 %qalloc.i, i64 0), !dbg !10
   tail call void @___qfree(i64 %qalloc.i), !dbg !10
-  %read_bool = tail call i1 @___read_future_bool(i64 %___lazy_measure), !dbg !10
-  tail call void @___dec_future_refcount(i64 %___lazy_measure), !dbg !10
+  %read_bool = tail call i1 @___read_future_bool(i64 %___future_measure), !dbg !10
+  tail call void @___dec_future_refcount(i64 %___future_measure), !dbg !10
   br i1 %read_bool, label %1, label %0
 
 0:                                                ; preds = %__hugr__.__tk2_sol_qalloc.40.exit
@@ -36,7 +36,7 @@ __hugr__.__tk2_sol_qalloc.40.exit:                ; preds = %alloca_block
   unreachable
 }
 
-declare i64 @___lazy_measure(i64, i64) local_unnamed_addr
+declare i64 @___future_measure(i64, i64) local_unnamed_addr
 
 declare void @___qfree(i64) local_unnamed_addr
 

--- a/qis-compiler/python/tests/snapshots/test_basic_generation/test_llvm/sol-x86_64-apple-darwin-postselect_panic/postselect_panic_x86_64-apple-darwin_sol
+++ b/qis-compiler/python/tests/snapshots/test_basic_generation/test_llvm/sol-x86_64-apple-darwin-postselect_panic/postselect_panic_x86_64-apple-darwin_sol
@@ -21,10 +21,10 @@ __hugr__.__tk2_sol_qalloc.38.exit:                ; preds = %alloca_block
   tail call void @___reset(i64 %qalloc.i), !dbg !8
   tail call void @___rp(i64 %qalloc.i, double 0x3FF921FB54442D18, double 0xBFF921FB54442D18), !dbg !9
   tail call void @___rz(i64 %qalloc.i, double 0x400921FB54442D18), !dbg !9
-  %___lazy_measure = tail call i64 @___lazy_measure(i64 %qalloc.i, i64 0), !dbg !10
+  %___future_measure = tail call i64 @___future_measure(i64 %qalloc.i, i64 0), !dbg !10
   tail call void @___qfree(i64 %qalloc.i), !dbg !10
-  %read_bool = tail call i1 @___read_future_bool(i64 %___lazy_measure), !dbg !10
-  tail call void @___dec_future_refcount(i64 %___lazy_measure), !dbg !10
+  %read_bool = tail call i1 @___read_future_bool(i64 %___future_measure), !dbg !10
+  tail call void @___dec_future_refcount(i64 %___future_measure), !dbg !10
   br i1 %read_bool, label %1, label %0
 
 0:                                                ; preds = %__hugr__.__tk2_sol_qalloc.38.exit
@@ -36,7 +36,7 @@ __hugr__.__tk2_sol_qalloc.38.exit:                ; preds = %alloca_block
   unreachable
 }
 
-declare i64 @___lazy_measure(i64, i64) local_unnamed_addr
+declare i64 @___future_measure(i64, i64) local_unnamed_addr
 
 declare void @___qfree(i64) local_unnamed_addr
 

--- a/qis-compiler/python/tests/snapshots/test_basic_generation/test_llvm/sol-x86_64-apple-darwin-rus/rus_x86_64-apple-darwin_sol
+++ b/qis-compiler/python/tests/snapshots/test_basic_generation/test_llvm/sol-x86_64-apple-darwin-rus/rus_x86_64-apple-darwin_sol
@@ -50,10 +50,10 @@ __hugr__.__tk2_sol_qalloc.94.exit94.i:            ; preds = %__hugr__.__tk2_sol_
   tail call void @___rp(i64 %qalloc.i91.i, double 0xBFF921FB54442D18, double 0x3FF921FB54442D18), !dbg !19
   tail call void @___rz(i64 %qalloc.i91.i, double 0xBFF921FB54442D18), !dbg !19
   tail call void @___rz(i64 %qalloc.i100.i, double 0x3FE921FB54442D18), !dbg !20
-  %___lazy_measure.i = tail call i64 @___lazy_measure(i64 %qalloc.i100.i, i64 0), !dbg !21
+  %___future_measure.i = tail call i64 @___future_measure(i64 %qalloc.i100.i, i64 0), !dbg !21
   tail call void @___qfree(i64 %qalloc.i100.i), !dbg !21
-  %read_bool.i.i = tail call i1 @___read_future_bool(i64 %___lazy_measure.i), !dbg !22
-  tail call void @___dec_future_refcount(i64 %___lazy_measure.i), !dbg !22
+  %read_bool.i.i = tail call i1 @___read_future_bool(i64 %___future_measure.i), !dbg !22
+  tail call void @___dec_future_refcount(i64 %___future_measure.i), !dbg !22
   br i1 %read_bool.i.i, label %1, label %0
 
 0:                                                ; preds = %__hugr__.__tk2_sol_qalloc.94.exit94.i
@@ -74,10 +74,10 @@ __hugr__.__tk2_sol_qalloc.94.exit94.i:            ; preds = %__hugr__.__tk2_sol_
   tail call void @___rp(i64 %qalloc.i, double 0xBFF921FB54442D18, double 0x3FF921FB54442D18), !dbg !32
   tail call void @___rz(i64 %qalloc.i, double 0xBFF921FB54442D18), !dbg !32
   tail call void @___rz(i64 %qalloc.i91.i, double 0x3FE921FB54442D18), !dbg !33
-  %___lazy_measure52.i = tail call i64 @___lazy_measure(i64 %qalloc.i91.i, i64 0), !dbg !34
+  %___future_measure52.i = tail call i64 @___future_measure(i64 %qalloc.i91.i, i64 0), !dbg !34
   tail call void @___qfree(i64 %qalloc.i91.i), !dbg !34
-  %read_bool.i97.i = tail call i1 @___read_future_bool(i64 %___lazy_measure52.i), !dbg !35
-  tail call void @___dec_future_refcount(i64 %___lazy_measure52.i), !dbg !35
+  %read_bool.i97.i = tail call i1 @___read_future_bool(i64 %___future_measure52.i), !dbg !35
+  tail call void @___dec_future_refcount(i64 %___future_measure52.i), !dbg !35
   br i1 %read_bool.i97.i, label %"__hugr__.__main__.rus.<locals>.rus.17.exit", label %2
 
 2:                                                ; preds = %1
@@ -85,15 +85,15 @@ __hugr__.__tk2_sol_qalloc.94.exit94.i:            ; preds = %__hugr__.__tk2_sol_
   br label %.backedge.i
 
 "__hugr__.__main__.rus.<locals>.rus.17.exit":     ; preds = %1
-  %___lazy_measure = tail call i64 @___lazy_measure(i64 %qalloc.i, i64 0), !dbg !38
+  %___future_measure = tail call i64 @___future_measure(i64 %qalloc.i, i64 0), !dbg !38
   tail call void @___qfree(i64 %qalloc.i), !dbg !38
-  %read_bool = tail call i1 @___read_future_bool(i64 %___lazy_measure), !dbg !38
-  tail call void @___dec_future_refcount(i64 %___lazy_measure), !dbg !38
+  %read_bool = tail call i1 @___read_future_bool(i64 %___future_measure), !dbg !38
+  tail call void @___dec_future_refcount(i64 %___future_measure), !dbg !38
   tail call void @print_bool(ptr nonnull @res_result.457DE32D.0, i64 16, i1 %read_bool), !dbg !39
   ret void
 }
 
-declare i64 @___lazy_measure(i64, i64) local_unnamed_addr
+declare i64 @___future_measure(i64, i64) local_unnamed_addr
 
 declare void @___qfree(i64) local_unnamed_addr
 

--- a/qis-compiler/python/tests/snapshots/test_basic_generation/test_llvm/sol-x86_64-apple-darwin-simple_modifier/simple_modifier_x86_64-apple-darwin_sol
+++ b/qis-compiler/python/tests/snapshots/test_basic_generation/test_llvm/sol-x86_64-apple-darwin-simple_modifier/simple_modifier_x86_64-apple-darwin_sol
@@ -60,15 +60,15 @@ __hugr__.__tk2_sol_qalloc.39.exit38:              ; preds = %__barray_check_none
   %7 = tail call ptr @heap_alloc(i64 8)
   store i64 0, ptr %7, align 1
   %8 = load i64, ptr %6, align 4
-  %___lazy_measure = tail call i64 @___lazy_measure(i64 %8, i64 0), !dbg !11
+  %___future_measure = tail call i64 @___future_measure(i64 %8, i64 0), !dbg !11
   tail call void @___qfree(i64 %8), !dbg !11
-  %read_bool = tail call i1 @___read_future_bool(i64 %___lazy_measure), !dbg !11
-  tail call void @___dec_future_refcount(i64 %___lazy_measure), !dbg !11
+  %read_bool = tail call i1 @___read_future_bool(i64 %___future_measure), !dbg !11
+  tail call void @___dec_future_refcount(i64 %___future_measure), !dbg !11
   tail call void @print_bool(ptr nonnull @res_c0.7C14CD6E.0, i64 12, i1 %read_bool), !dbg !12
-  %___lazy_measure19 = tail call i64 @___lazy_measure(i64 %qalloc.i35, i64 0), !dbg !13
+  %___future_measure19 = tail call i64 @___future_measure(i64 %qalloc.i35, i64 0), !dbg !13
   tail call void @___qfree(i64 %qalloc.i35), !dbg !13
-  %read_bool21 = tail call i1 @___read_future_bool(i64 %___lazy_measure19), !dbg !13
-  tail call void @___dec_future_refcount(i64 %___lazy_measure19), !dbg !13
+  %read_bool21 = tail call i1 @___read_future_bool(i64 %___future_measure19), !dbg !13
+  tail call void @___dec_future_refcount(i64 %___future_measure19), !dbg !13
   tail call void @print_bool(ptr nonnull @res_c1.1F7A6571.0, i64 12, i1 %read_bool21), !dbg !14
   ret void
 }
@@ -78,7 +78,7 @@ declare ptr @heap_alloc(i64) local_unnamed_addr
 ; Function Attrs: noreturn
 declare void @panic(i32, ptr) local_unnamed_addr #0
 
-declare i64 @___lazy_measure(i64, i64) local_unnamed_addr
+declare i64 @___future_measure(i64, i64) local_unnamed_addr
 
 declare void @___qfree(i64) local_unnamed_addr
 

--- a/qis-compiler/python/tests/snapshots/test_basic_generation/test_llvm/sol-x86_64-unknown-linux-gnu-flip_some/flip_some_x86_64-unknown-linux-gnu_sol
+++ b/qis-compiler/python/tests/snapshots/test_basic_generation/test_llvm/sol-x86_64-unknown-linux-gnu-flip_some/flip_some_x86_64-unknown-linux-gnu_sol
@@ -53,31 +53,31 @@ cond_40_case_0.i44:                               ; preds = %__hugr__.__tk2_sol_
 
 __hugr__.__tk2_sol_qalloc.36.exit45:              ; preds = %__hugr__.__tk2_sol_qalloc.36.exit41
   tail call void @___reset(i64 %qalloc.i42), !dbg !13
-  %___lazy_measure = tail call i64 @___lazy_measure(i64 %qalloc.i, i64 0), !dbg !14
+  %___future_measure = tail call i64 @___future_measure(i64 %qalloc.i, i64 0), !dbg !14
   tail call void @___qfree(i64 %qalloc.i), !dbg !14
   tail call void @___rp(i64 %qalloc.i42, double 0x400921FB54442D18, double 0.000000e+00), !dbg !15
-  %read_bool = tail call i1 @___read_future_bool(i64 %___lazy_measure), !dbg !14
-  tail call void @___dec_future_refcount(i64 %___lazy_measure), !dbg !14
+  %read_bool = tail call i1 @___read_future_bool(i64 %___future_measure), !dbg !14
+  tail call void @___dec_future_refcount(i64 %___future_measure), !dbg !14
   tail call void @print_bool(ptr nonnull @res_c0.7C14CD6E.0, i64 12, i1 %read_bool), !dbg !16
-  %___lazy_measure9 = tail call i64 @___lazy_measure(i64 %qalloc.i34, i64 0), !dbg !17
+  %___future_measure9 = tail call i64 @___future_measure(i64 %qalloc.i34, i64 0), !dbg !17
   tail call void @___qfree(i64 %qalloc.i34), !dbg !17
-  %read_bool11 = tail call i1 @___read_future_bool(i64 %___lazy_measure9), !dbg !17
-  tail call void @___dec_future_refcount(i64 %___lazy_measure9), !dbg !17
+  %read_bool11 = tail call i1 @___read_future_bool(i64 %___future_measure9), !dbg !17
+  tail call void @___dec_future_refcount(i64 %___future_measure9), !dbg !17
   tail call void @print_bool(ptr nonnull @res_c1.1F7A6571.0, i64 12, i1 %read_bool11), !dbg !18
-  %___lazy_measure17 = tail call i64 @___lazy_measure(i64 %qalloc.i38, i64 0), !dbg !19
+  %___future_measure17 = tail call i64 @___future_measure(i64 %qalloc.i38, i64 0), !dbg !19
   tail call void @___qfree(i64 %qalloc.i38), !dbg !19
-  %read_bool19 = tail call i1 @___read_future_bool(i64 %___lazy_measure17), !dbg !19
-  tail call void @___dec_future_refcount(i64 %___lazy_measure17), !dbg !19
+  %read_bool19 = tail call i1 @___read_future_bool(i64 %___future_measure17), !dbg !19
+  tail call void @___dec_future_refcount(i64 %___future_measure17), !dbg !19
   tail call void @print_bool(ptr nonnull @res_c2.60825383.0, i64 12, i1 %read_bool19), !dbg !20
-  %___lazy_measure25 = tail call i64 @___lazy_measure(i64 %qalloc.i42, i64 0), !dbg !21
+  %___future_measure25 = tail call i64 @___future_measure(i64 %qalloc.i42, i64 0), !dbg !21
   tail call void @___qfree(i64 %qalloc.i42), !dbg !21
-  %read_bool27 = tail call i1 @___read_future_bool(i64 %___lazy_measure25), !dbg !21
-  tail call void @___dec_future_refcount(i64 %___lazy_measure25), !dbg !21
+  %read_bool27 = tail call i1 @___read_future_bool(i64 %___future_measure25), !dbg !21
+  tail call void @___dec_future_refcount(i64 %___future_measure25), !dbg !21
   tail call void @print_bool(ptr nonnull @res_c3.B223E16D.0, i64 12, i1 %read_bool27), !dbg !22
   ret void
 }
 
-declare i64 @___lazy_measure(i64, i64) local_unnamed_addr
+declare i64 @___future_measure(i64, i64) local_unnamed_addr
 
 declare void @___qfree(i64) local_unnamed_addr
 

--- a/qis-compiler/python/tests/snapshots/test_basic_generation/test_llvm/sol-x86_64-unknown-linux-gnu-measure_qb_array/measure_qb_array_x86_64-unknown-linux-gnu_sol
+++ b/qis-compiler/python/tests/snapshots/test_basic_generation/test_llvm/sol-x86_64-unknown-linux-gnu-measure_qb_array/measure_qb_array_x86_64-unknown-linux-gnu_sol
@@ -364,7 +364,7 @@ __barray_check_bounds.exit.i:                     ; preds = %__barray_check_boun
   store i64 %106, ptr %100, align 4, !dbg !58
   %107 = getelementptr inbounds i64, ptr %.fca.0.extract62.i179.i, i64 %98, !dbg !57
   %108 = load i64, ptr %107, align 4, !dbg !57
-  %___lazy_measure.i = tail call i64 @___lazy_measure(i64 %108, i64 0), !dbg !60
+  %___future_measure.i = tail call i64 @___future_measure(i64 %108, i64 0), !dbg !60
   tail call void @___qfree(i64 %108), !dbg !60
   %109 = load i64, ptr %74, align 4
   %110 = lshr i64 %109, %"200_0.sroa.15.0178.i"
@@ -381,7 +381,7 @@ loop_body.i:                                      ; preds = %__barray_check_boun
   %114 = xor i64 %109, %113
   store i64 %114, ptr %74, align 4
   %115 = getelementptr inbounds nuw i64, ptr %73, i64 %"200_0.sroa.15.0178.i"
-  store i64 %___lazy_measure.i, ptr %115, align 4
+  store i64 %___future_measure.i, ptr %115, align 4
   %116 = extractvalue { { ptr, ptr, i64 }, i64 } %.pn159177.i, 0
   %.fca.0.extract62.i.i = extractvalue { ptr, ptr, i64 } %116, 0
   %.fca.1.extract63.i.i = extractvalue { ptr, ptr, i64 } %116, 1
@@ -554,7 +554,7 @@ declare i1 @___read_future_bool(i64) local_unnamed_addr
 
 declare void @___dec_future_refcount(i64) local_unnamed_addr
 
-declare i64 @___lazy_measure(i64, i64) local_unnamed_addr
+declare i64 @___future_measure(i64, i64) local_unnamed_addr
 
 declare void @___qfree(i64) local_unnamed_addr
 

--- a/qis-compiler/python/tests/snapshots/test_basic_generation/test_llvm/sol-x86_64-unknown-linux-gnu-no_results/no_results_x86_64-unknown-linux-gnu_sol
+++ b/qis-compiler/python/tests/snapshots/test_basic_generation/test_llvm/sol-x86_64-unknown-linux-gnu-no_results/no_results_x86_64-unknown-linux-gnu_sol
@@ -19,14 +19,14 @@ __hugr__.__tk2_sol_qalloc.15.exit:                ; preds = %alloca_block
   tail call void @___reset(i64 %qalloc.i), !dbg !8
   tail call void @___rp(i64 %qalloc.i, double 0x3FF921FB54442D18, double 0xBFF921FB54442D18), !dbg !9
   tail call void @___rz(i64 %qalloc.i, double 0x400921FB54442D18), !dbg !9
-  %___lazy_measure = tail call i64 @___lazy_measure(i64 %qalloc.i, i64 0), !dbg !10
+  %___future_measure = tail call i64 @___future_measure(i64 %qalloc.i, i64 0), !dbg !10
   tail call void @___qfree(i64 %qalloc.i), !dbg !10
-  %read_bool = tail call i1 @___read_future_bool(i64 %___lazy_measure), !dbg !10
-  tail call void @___dec_future_refcount(i64 %___lazy_measure), !dbg !10
+  %read_bool = tail call i1 @___read_future_bool(i64 %___future_measure), !dbg !10
+  tail call void @___dec_future_refcount(i64 %___future_measure), !dbg !10
   ret void
 }
 
-declare i64 @___lazy_measure(i64, i64) local_unnamed_addr
+declare i64 @___future_measure(i64, i64) local_unnamed_addr
 
 declare void @___qfree(i64) local_unnamed_addr
 

--- a/qis-compiler/python/tests/snapshots/test_basic_generation/test_llvm/sol-x86_64-unknown-linux-gnu-postselect_exit/postselect_exit_x86_64-unknown-linux-gnu_sol
+++ b/qis-compiler/python/tests/snapshots/test_basic_generation/test_llvm/sol-x86_64-unknown-linux-gnu-postselect_exit/postselect_exit_x86_64-unknown-linux-gnu_sol
@@ -21,10 +21,10 @@ __hugr__.__tk2_sol_qalloc.40.exit:                ; preds = %alloca_block
   tail call void @___reset(i64 %qalloc.i), !dbg !8
   tail call void @___rp(i64 %qalloc.i, double 0x3FF921FB54442D18, double 0xBFF921FB54442D18), !dbg !9
   tail call void @___rz(i64 %qalloc.i, double 0x400921FB54442D18), !dbg !9
-  %___lazy_measure = tail call i64 @___lazy_measure(i64 %qalloc.i, i64 0), !dbg !10
+  %___future_measure = tail call i64 @___future_measure(i64 %qalloc.i, i64 0), !dbg !10
   tail call void @___qfree(i64 %qalloc.i), !dbg !10
-  %read_bool = tail call i1 @___read_future_bool(i64 %___lazy_measure), !dbg !10
-  tail call void @___dec_future_refcount(i64 %___lazy_measure), !dbg !10
+  %read_bool = tail call i1 @___read_future_bool(i64 %___future_measure), !dbg !10
+  tail call void @___dec_future_refcount(i64 %___future_measure), !dbg !10
   br i1 %read_bool, label %1, label %0
 
 0:                                                ; preds = %__hugr__.__tk2_sol_qalloc.40.exit
@@ -36,7 +36,7 @@ __hugr__.__tk2_sol_qalloc.40.exit:                ; preds = %alloca_block
   unreachable
 }
 
-declare i64 @___lazy_measure(i64, i64) local_unnamed_addr
+declare i64 @___future_measure(i64, i64) local_unnamed_addr
 
 declare void @___qfree(i64) local_unnamed_addr
 

--- a/qis-compiler/python/tests/snapshots/test_basic_generation/test_llvm/sol-x86_64-unknown-linux-gnu-postselect_panic/postselect_panic_x86_64-unknown-linux-gnu_sol
+++ b/qis-compiler/python/tests/snapshots/test_basic_generation/test_llvm/sol-x86_64-unknown-linux-gnu-postselect_panic/postselect_panic_x86_64-unknown-linux-gnu_sol
@@ -21,10 +21,10 @@ __hugr__.__tk2_sol_qalloc.38.exit:                ; preds = %alloca_block
   tail call void @___reset(i64 %qalloc.i), !dbg !8
   tail call void @___rp(i64 %qalloc.i, double 0x3FF921FB54442D18, double 0xBFF921FB54442D18), !dbg !9
   tail call void @___rz(i64 %qalloc.i, double 0x400921FB54442D18), !dbg !9
-  %___lazy_measure = tail call i64 @___lazy_measure(i64 %qalloc.i, i64 0), !dbg !10
+  %___future_measure = tail call i64 @___future_measure(i64 %qalloc.i, i64 0), !dbg !10
   tail call void @___qfree(i64 %qalloc.i), !dbg !10
-  %read_bool = tail call i1 @___read_future_bool(i64 %___lazy_measure), !dbg !10
-  tail call void @___dec_future_refcount(i64 %___lazy_measure), !dbg !10
+  %read_bool = tail call i1 @___read_future_bool(i64 %___future_measure), !dbg !10
+  tail call void @___dec_future_refcount(i64 %___future_measure), !dbg !10
   br i1 %read_bool, label %1, label %0
 
 0:                                                ; preds = %__hugr__.__tk2_sol_qalloc.38.exit
@@ -36,7 +36,7 @@ __hugr__.__tk2_sol_qalloc.38.exit:                ; preds = %alloca_block
   unreachable
 }
 
-declare i64 @___lazy_measure(i64, i64) local_unnamed_addr
+declare i64 @___future_measure(i64, i64) local_unnamed_addr
 
 declare void @___qfree(i64) local_unnamed_addr
 

--- a/qis-compiler/python/tests/snapshots/test_basic_generation/test_llvm/sol-x86_64-unknown-linux-gnu-rus/rus_x86_64-unknown-linux-gnu_sol
+++ b/qis-compiler/python/tests/snapshots/test_basic_generation/test_llvm/sol-x86_64-unknown-linux-gnu-rus/rus_x86_64-unknown-linux-gnu_sol
@@ -50,10 +50,10 @@ __hugr__.__tk2_sol_qalloc.94.exit94.i:            ; preds = %__hugr__.__tk2_sol_
   tail call void @___rp(i64 %qalloc.i91.i, double 0xBFF921FB54442D18, double 0x3FF921FB54442D18), !dbg !19
   tail call void @___rz(i64 %qalloc.i91.i, double 0xBFF921FB54442D18), !dbg !19
   tail call void @___rz(i64 %qalloc.i100.i, double 0x3FE921FB54442D18), !dbg !20
-  %___lazy_measure.i = tail call i64 @___lazy_measure(i64 %qalloc.i100.i, i64 0), !dbg !21
+  %___future_measure.i = tail call i64 @___future_measure(i64 %qalloc.i100.i, i64 0), !dbg !21
   tail call void @___qfree(i64 %qalloc.i100.i), !dbg !21
-  %read_bool.i.i = tail call i1 @___read_future_bool(i64 %___lazy_measure.i), !dbg !22
-  tail call void @___dec_future_refcount(i64 %___lazy_measure.i), !dbg !22
+  %read_bool.i.i = tail call i1 @___read_future_bool(i64 %___future_measure.i), !dbg !22
+  tail call void @___dec_future_refcount(i64 %___future_measure.i), !dbg !22
   br i1 %read_bool.i.i, label %1, label %0
 
 0:                                                ; preds = %__hugr__.__tk2_sol_qalloc.94.exit94.i
@@ -74,10 +74,10 @@ __hugr__.__tk2_sol_qalloc.94.exit94.i:            ; preds = %__hugr__.__tk2_sol_
   tail call void @___rp(i64 %qalloc.i, double 0xBFF921FB54442D18, double 0x3FF921FB54442D18), !dbg !32
   tail call void @___rz(i64 %qalloc.i, double 0xBFF921FB54442D18), !dbg !32
   tail call void @___rz(i64 %qalloc.i91.i, double 0x3FE921FB54442D18), !dbg !33
-  %___lazy_measure52.i = tail call i64 @___lazy_measure(i64 %qalloc.i91.i, i64 0), !dbg !34
+  %___future_measure52.i = tail call i64 @___future_measure(i64 %qalloc.i91.i, i64 0), !dbg !34
   tail call void @___qfree(i64 %qalloc.i91.i), !dbg !34
-  %read_bool.i97.i = tail call i1 @___read_future_bool(i64 %___lazy_measure52.i), !dbg !35
-  tail call void @___dec_future_refcount(i64 %___lazy_measure52.i), !dbg !35
+  %read_bool.i97.i = tail call i1 @___read_future_bool(i64 %___future_measure52.i), !dbg !35
+  tail call void @___dec_future_refcount(i64 %___future_measure52.i), !dbg !35
   br i1 %read_bool.i97.i, label %"__hugr__.__main__.rus.<locals>.rus.17.exit", label %2
 
 2:                                                ; preds = %1
@@ -85,15 +85,15 @@ __hugr__.__tk2_sol_qalloc.94.exit94.i:            ; preds = %__hugr__.__tk2_sol_
   br label %.backedge.i
 
 "__hugr__.__main__.rus.<locals>.rus.17.exit":     ; preds = %1
-  %___lazy_measure = tail call i64 @___lazy_measure(i64 %qalloc.i, i64 0), !dbg !38
+  %___future_measure = tail call i64 @___future_measure(i64 %qalloc.i, i64 0), !dbg !38
   tail call void @___qfree(i64 %qalloc.i), !dbg !38
-  %read_bool = tail call i1 @___read_future_bool(i64 %___lazy_measure), !dbg !38
-  tail call void @___dec_future_refcount(i64 %___lazy_measure), !dbg !38
+  %read_bool = tail call i1 @___read_future_bool(i64 %___future_measure), !dbg !38
+  tail call void @___dec_future_refcount(i64 %___future_measure), !dbg !38
   tail call void @print_bool(ptr nonnull @res_result.457DE32D.0, i64 16, i1 %read_bool), !dbg !39
   ret void
 }
 
-declare i64 @___lazy_measure(i64, i64) local_unnamed_addr
+declare i64 @___future_measure(i64, i64) local_unnamed_addr
 
 declare void @___qfree(i64) local_unnamed_addr
 

--- a/qis-compiler/python/tests/snapshots/test_basic_generation/test_llvm/sol-x86_64-unknown-linux-gnu-simple_modifier/simple_modifier_x86_64-unknown-linux-gnu_sol
+++ b/qis-compiler/python/tests/snapshots/test_basic_generation/test_llvm/sol-x86_64-unknown-linux-gnu-simple_modifier/simple_modifier_x86_64-unknown-linux-gnu_sol
@@ -60,15 +60,15 @@ __hugr__.__tk2_sol_qalloc.39.exit38:              ; preds = %__barray_check_none
   %7 = tail call ptr @heap_alloc(i64 8)
   store i64 0, ptr %7, align 1
   %8 = load i64, ptr %6, align 4
-  %___lazy_measure = tail call i64 @___lazy_measure(i64 %8, i64 0), !dbg !11
+  %___future_measure = tail call i64 @___future_measure(i64 %8, i64 0), !dbg !11
   tail call void @___qfree(i64 %8), !dbg !11
-  %read_bool = tail call i1 @___read_future_bool(i64 %___lazy_measure), !dbg !11
-  tail call void @___dec_future_refcount(i64 %___lazy_measure), !dbg !11
+  %read_bool = tail call i1 @___read_future_bool(i64 %___future_measure), !dbg !11
+  tail call void @___dec_future_refcount(i64 %___future_measure), !dbg !11
   tail call void @print_bool(ptr nonnull @res_c0.7C14CD6E.0, i64 12, i1 %read_bool), !dbg !12
-  %___lazy_measure19 = tail call i64 @___lazy_measure(i64 %qalloc.i35, i64 0), !dbg !13
+  %___future_measure19 = tail call i64 @___future_measure(i64 %qalloc.i35, i64 0), !dbg !13
   tail call void @___qfree(i64 %qalloc.i35), !dbg !13
-  %read_bool21 = tail call i1 @___read_future_bool(i64 %___lazy_measure19), !dbg !13
-  tail call void @___dec_future_refcount(i64 %___lazy_measure19), !dbg !13
+  %read_bool21 = tail call i1 @___read_future_bool(i64 %___future_measure19), !dbg !13
+  tail call void @___dec_future_refcount(i64 %___future_measure19), !dbg !13
   tail call void @print_bool(ptr nonnull @res_c1.1F7A6571.0, i64 12, i1 %read_bool21), !dbg !14
   ret void
 }
@@ -78,7 +78,7 @@ declare ptr @heap_alloc(i64) local_unnamed_addr
 ; Function Attrs: noreturn
 declare void @panic(i32, ptr) local_unnamed_addr #0
 
-declare i64 @___lazy_measure(i64, i64) local_unnamed_addr
+declare i64 @___future_measure(i64, i64) local_unnamed_addr
 
 declare void @___qfree(i64) local_unnamed_addr
 

--- a/qis-compiler/python/tests/snapshots/test_basic_generation/test_llvm/sol-x86_64-windows-msvc-flip_some/flip_some_x86_64-windows-msvc_sol
+++ b/qis-compiler/python/tests/snapshots/test_basic_generation/test_llvm/sol-x86_64-windows-msvc-flip_some/flip_some_x86_64-windows-msvc_sol
@@ -53,31 +53,31 @@ cond_40_case_0.i44:                               ; preds = %__hugr__.__tk2_sol_
 
 __hugr__.__tk2_sol_qalloc.36.exit45:              ; preds = %__hugr__.__tk2_sol_qalloc.36.exit41
   tail call void @___reset(i64 %qalloc.i42), !dbg !13
-  %___lazy_measure = tail call i64 @___lazy_measure(i64 %qalloc.i, i64 0), !dbg !14
+  %___future_measure = tail call i64 @___future_measure(i64 %qalloc.i, i64 0), !dbg !14
   tail call void @___qfree(i64 %qalloc.i), !dbg !14
   tail call void @___rp(i64 %qalloc.i42, double 0x400921FB54442D18, double 0.000000e+00), !dbg !15
-  %read_bool = tail call i1 @___read_future_bool(i64 %___lazy_measure), !dbg !14
-  tail call void @___dec_future_refcount(i64 %___lazy_measure), !dbg !14
+  %read_bool = tail call i1 @___read_future_bool(i64 %___future_measure), !dbg !14
+  tail call void @___dec_future_refcount(i64 %___future_measure), !dbg !14
   tail call void @print_bool(ptr nonnull @res_c0.7C14CD6E.0, i64 12, i1 %read_bool), !dbg !16
-  %___lazy_measure9 = tail call i64 @___lazy_measure(i64 %qalloc.i34, i64 0), !dbg !17
+  %___future_measure9 = tail call i64 @___future_measure(i64 %qalloc.i34, i64 0), !dbg !17
   tail call void @___qfree(i64 %qalloc.i34), !dbg !17
-  %read_bool11 = tail call i1 @___read_future_bool(i64 %___lazy_measure9), !dbg !17
-  tail call void @___dec_future_refcount(i64 %___lazy_measure9), !dbg !17
+  %read_bool11 = tail call i1 @___read_future_bool(i64 %___future_measure9), !dbg !17
+  tail call void @___dec_future_refcount(i64 %___future_measure9), !dbg !17
   tail call void @print_bool(ptr nonnull @res_c1.1F7A6571.0, i64 12, i1 %read_bool11), !dbg !18
-  %___lazy_measure17 = tail call i64 @___lazy_measure(i64 %qalloc.i38, i64 0), !dbg !19
+  %___future_measure17 = tail call i64 @___future_measure(i64 %qalloc.i38, i64 0), !dbg !19
   tail call void @___qfree(i64 %qalloc.i38), !dbg !19
-  %read_bool19 = tail call i1 @___read_future_bool(i64 %___lazy_measure17), !dbg !19
-  tail call void @___dec_future_refcount(i64 %___lazy_measure17), !dbg !19
+  %read_bool19 = tail call i1 @___read_future_bool(i64 %___future_measure17), !dbg !19
+  tail call void @___dec_future_refcount(i64 %___future_measure17), !dbg !19
   tail call void @print_bool(ptr nonnull @res_c2.60825383.0, i64 12, i1 %read_bool19), !dbg !20
-  %___lazy_measure25 = tail call i64 @___lazy_measure(i64 %qalloc.i42, i64 0), !dbg !21
+  %___future_measure25 = tail call i64 @___future_measure(i64 %qalloc.i42, i64 0), !dbg !21
   tail call void @___qfree(i64 %qalloc.i42), !dbg !21
-  %read_bool27 = tail call i1 @___read_future_bool(i64 %___lazy_measure25), !dbg !21
-  tail call void @___dec_future_refcount(i64 %___lazy_measure25), !dbg !21
+  %read_bool27 = tail call i1 @___read_future_bool(i64 %___future_measure25), !dbg !21
+  tail call void @___dec_future_refcount(i64 %___future_measure25), !dbg !21
   tail call void @print_bool(ptr nonnull @res_c3.B223E16D.0, i64 12, i1 %read_bool27), !dbg !22
   ret void
 }
 
-declare i64 @___lazy_measure(i64, i64) local_unnamed_addr
+declare i64 @___future_measure(i64, i64) local_unnamed_addr
 
 declare void @___qfree(i64) local_unnamed_addr
 

--- a/qis-compiler/python/tests/snapshots/test_basic_generation/test_llvm/sol-x86_64-windows-msvc-measure_qb_array/measure_qb_array_x86_64-windows-msvc_sol
+++ b/qis-compiler/python/tests/snapshots/test_basic_generation/test_llvm/sol-x86_64-windows-msvc-measure_qb_array/measure_qb_array_x86_64-windows-msvc_sol
@@ -364,7 +364,7 @@ __barray_check_bounds.exit.i:                     ; preds = %__barray_check_boun
   store i64 %106, ptr %100, align 4, !dbg !58
   %107 = getelementptr inbounds i64, ptr %.fca.0.extract62.i179.i, i64 %98, !dbg !57
   %108 = load i64, ptr %107, align 4, !dbg !57
-  %___lazy_measure.i = tail call i64 @___lazy_measure(i64 %108, i64 0), !dbg !60
+  %___future_measure.i = tail call i64 @___future_measure(i64 %108, i64 0), !dbg !60
   tail call void @___qfree(i64 %108), !dbg !60
   %109 = load i64, ptr %74, align 4
   %110 = lshr i64 %109, %"200_0.sroa.15.0178.i"
@@ -381,7 +381,7 @@ loop_body.i:                                      ; preds = %__barray_check_boun
   %114 = xor i64 %109, %113
   store i64 %114, ptr %74, align 4
   %115 = getelementptr inbounds nuw i64, ptr %73, i64 %"200_0.sroa.15.0178.i"
-  store i64 %___lazy_measure.i, ptr %115, align 4
+  store i64 %___future_measure.i, ptr %115, align 4
   %116 = extractvalue { { ptr, ptr, i64 }, i64 } %.pn159177.i, 0
   %.fca.0.extract62.i.i = extractvalue { ptr, ptr, i64 } %116, 0
   %.fca.1.extract63.i.i = extractvalue { ptr, ptr, i64 } %116, 1
@@ -554,7 +554,7 @@ declare i1 @___read_future_bool(i64) local_unnamed_addr
 
 declare void @___dec_future_refcount(i64) local_unnamed_addr
 
-declare i64 @___lazy_measure(i64, i64) local_unnamed_addr
+declare i64 @___future_measure(i64, i64) local_unnamed_addr
 
 declare void @___qfree(i64) local_unnamed_addr
 

--- a/qis-compiler/python/tests/snapshots/test_basic_generation/test_llvm/sol-x86_64-windows-msvc-no_results/no_results_x86_64-windows-msvc_sol
+++ b/qis-compiler/python/tests/snapshots/test_basic_generation/test_llvm/sol-x86_64-windows-msvc-no_results/no_results_x86_64-windows-msvc_sol
@@ -19,14 +19,14 @@ __hugr__.__tk2_sol_qalloc.15.exit:                ; preds = %alloca_block
   tail call void @___reset(i64 %qalloc.i), !dbg !8
   tail call void @___rp(i64 %qalloc.i, double 0x3FF921FB54442D18, double 0xBFF921FB54442D18), !dbg !9
   tail call void @___rz(i64 %qalloc.i, double 0x400921FB54442D18), !dbg !9
-  %___lazy_measure = tail call i64 @___lazy_measure(i64 %qalloc.i, i64 0), !dbg !10
+  %___future_measure = tail call i64 @___future_measure(i64 %qalloc.i, i64 0), !dbg !10
   tail call void @___qfree(i64 %qalloc.i), !dbg !10
-  %read_bool = tail call i1 @___read_future_bool(i64 %___lazy_measure), !dbg !10
-  tail call void @___dec_future_refcount(i64 %___lazy_measure), !dbg !10
+  %read_bool = tail call i1 @___read_future_bool(i64 %___future_measure), !dbg !10
+  tail call void @___dec_future_refcount(i64 %___future_measure), !dbg !10
   ret void
 }
 
-declare i64 @___lazy_measure(i64, i64) local_unnamed_addr
+declare i64 @___future_measure(i64, i64) local_unnamed_addr
 
 declare void @___qfree(i64) local_unnamed_addr
 

--- a/qis-compiler/python/tests/snapshots/test_basic_generation/test_llvm/sol-x86_64-windows-msvc-postselect_exit/postselect_exit_x86_64-windows-msvc_sol
+++ b/qis-compiler/python/tests/snapshots/test_basic_generation/test_llvm/sol-x86_64-windows-msvc-postselect_exit/postselect_exit_x86_64-windows-msvc_sol
@@ -21,10 +21,10 @@ __hugr__.__tk2_sol_qalloc.40.exit:                ; preds = %alloca_block
   tail call void @___reset(i64 %qalloc.i), !dbg !8
   tail call void @___rp(i64 %qalloc.i, double 0x3FF921FB54442D18, double 0xBFF921FB54442D18), !dbg !9
   tail call void @___rz(i64 %qalloc.i, double 0x400921FB54442D18), !dbg !9
-  %___lazy_measure = tail call i64 @___lazy_measure(i64 %qalloc.i, i64 0), !dbg !10
+  %___future_measure = tail call i64 @___future_measure(i64 %qalloc.i, i64 0), !dbg !10
   tail call void @___qfree(i64 %qalloc.i), !dbg !10
-  %read_bool = tail call i1 @___read_future_bool(i64 %___lazy_measure), !dbg !10
-  tail call void @___dec_future_refcount(i64 %___lazy_measure), !dbg !10
+  %read_bool = tail call i1 @___read_future_bool(i64 %___future_measure), !dbg !10
+  tail call void @___dec_future_refcount(i64 %___future_measure), !dbg !10
   br i1 %read_bool, label %1, label %0
 
 0:                                                ; preds = %__hugr__.__tk2_sol_qalloc.40.exit
@@ -36,7 +36,7 @@ __hugr__.__tk2_sol_qalloc.40.exit:                ; preds = %alloca_block
   unreachable
 }
 
-declare i64 @___lazy_measure(i64, i64) local_unnamed_addr
+declare i64 @___future_measure(i64, i64) local_unnamed_addr
 
 declare void @___qfree(i64) local_unnamed_addr
 

--- a/qis-compiler/python/tests/snapshots/test_basic_generation/test_llvm/sol-x86_64-windows-msvc-postselect_panic/postselect_panic_x86_64-windows-msvc_sol
+++ b/qis-compiler/python/tests/snapshots/test_basic_generation/test_llvm/sol-x86_64-windows-msvc-postselect_panic/postselect_panic_x86_64-windows-msvc_sol
@@ -21,10 +21,10 @@ __hugr__.__tk2_sol_qalloc.38.exit:                ; preds = %alloca_block
   tail call void @___reset(i64 %qalloc.i), !dbg !8
   tail call void @___rp(i64 %qalloc.i, double 0x3FF921FB54442D18, double 0xBFF921FB54442D18), !dbg !9
   tail call void @___rz(i64 %qalloc.i, double 0x400921FB54442D18), !dbg !9
-  %___lazy_measure = tail call i64 @___lazy_measure(i64 %qalloc.i, i64 0), !dbg !10
+  %___future_measure = tail call i64 @___future_measure(i64 %qalloc.i, i64 0), !dbg !10
   tail call void @___qfree(i64 %qalloc.i), !dbg !10
-  %read_bool = tail call i1 @___read_future_bool(i64 %___lazy_measure), !dbg !10
-  tail call void @___dec_future_refcount(i64 %___lazy_measure), !dbg !10
+  %read_bool = tail call i1 @___read_future_bool(i64 %___future_measure), !dbg !10
+  tail call void @___dec_future_refcount(i64 %___future_measure), !dbg !10
   br i1 %read_bool, label %1, label %0
 
 0:                                                ; preds = %__hugr__.__tk2_sol_qalloc.38.exit
@@ -36,7 +36,7 @@ __hugr__.__tk2_sol_qalloc.38.exit:                ; preds = %alloca_block
   unreachable
 }
 
-declare i64 @___lazy_measure(i64, i64) local_unnamed_addr
+declare i64 @___future_measure(i64, i64) local_unnamed_addr
 
 declare void @___qfree(i64) local_unnamed_addr
 

--- a/qis-compiler/python/tests/snapshots/test_basic_generation/test_llvm/sol-x86_64-windows-msvc-rus/rus_x86_64-windows-msvc_sol
+++ b/qis-compiler/python/tests/snapshots/test_basic_generation/test_llvm/sol-x86_64-windows-msvc-rus/rus_x86_64-windows-msvc_sol
@@ -50,10 +50,10 @@ __hugr__.__tk2_sol_qalloc.94.exit94.i:            ; preds = %__hugr__.__tk2_sol_
   tail call void @___rp(i64 %qalloc.i91.i, double 0xBFF921FB54442D18, double 0x3FF921FB54442D18), !dbg !19
   tail call void @___rz(i64 %qalloc.i91.i, double 0xBFF921FB54442D18), !dbg !19
   tail call void @___rz(i64 %qalloc.i100.i, double 0x3FE921FB54442D18), !dbg !20
-  %___lazy_measure.i = tail call i64 @___lazy_measure(i64 %qalloc.i100.i, i64 0), !dbg !21
+  %___future_measure.i = tail call i64 @___future_measure(i64 %qalloc.i100.i, i64 0), !dbg !21
   tail call void @___qfree(i64 %qalloc.i100.i), !dbg !21
-  %read_bool.i.i = tail call i1 @___read_future_bool(i64 %___lazy_measure.i), !dbg !22
-  tail call void @___dec_future_refcount(i64 %___lazy_measure.i), !dbg !22
+  %read_bool.i.i = tail call i1 @___read_future_bool(i64 %___future_measure.i), !dbg !22
+  tail call void @___dec_future_refcount(i64 %___future_measure.i), !dbg !22
   br i1 %read_bool.i.i, label %1, label %0
 
 0:                                                ; preds = %__hugr__.__tk2_sol_qalloc.94.exit94.i
@@ -74,10 +74,10 @@ __hugr__.__tk2_sol_qalloc.94.exit94.i:            ; preds = %__hugr__.__tk2_sol_
   tail call void @___rp(i64 %qalloc.i, double 0xBFF921FB54442D18, double 0x3FF921FB54442D18), !dbg !32
   tail call void @___rz(i64 %qalloc.i, double 0xBFF921FB54442D18), !dbg !32
   tail call void @___rz(i64 %qalloc.i91.i, double 0x3FE921FB54442D18), !dbg !33
-  %___lazy_measure52.i = tail call i64 @___lazy_measure(i64 %qalloc.i91.i, i64 0), !dbg !34
+  %___future_measure52.i = tail call i64 @___future_measure(i64 %qalloc.i91.i, i64 0), !dbg !34
   tail call void @___qfree(i64 %qalloc.i91.i), !dbg !34
-  %read_bool.i97.i = tail call i1 @___read_future_bool(i64 %___lazy_measure52.i), !dbg !35
-  tail call void @___dec_future_refcount(i64 %___lazy_measure52.i), !dbg !35
+  %read_bool.i97.i = tail call i1 @___read_future_bool(i64 %___future_measure52.i), !dbg !35
+  tail call void @___dec_future_refcount(i64 %___future_measure52.i), !dbg !35
   br i1 %read_bool.i97.i, label %"__hugr__.__main__.rus.<locals>.rus.17.exit", label %2
 
 2:                                                ; preds = %1
@@ -85,15 +85,15 @@ __hugr__.__tk2_sol_qalloc.94.exit94.i:            ; preds = %__hugr__.__tk2_sol_
   br label %.backedge.i
 
 "__hugr__.__main__.rus.<locals>.rus.17.exit":     ; preds = %1
-  %___lazy_measure = tail call i64 @___lazy_measure(i64 %qalloc.i, i64 0), !dbg !38
+  %___future_measure = tail call i64 @___future_measure(i64 %qalloc.i, i64 0), !dbg !38
   tail call void @___qfree(i64 %qalloc.i), !dbg !38
-  %read_bool = tail call i1 @___read_future_bool(i64 %___lazy_measure), !dbg !38
-  tail call void @___dec_future_refcount(i64 %___lazy_measure), !dbg !38
+  %read_bool = tail call i1 @___read_future_bool(i64 %___future_measure), !dbg !38
+  tail call void @___dec_future_refcount(i64 %___future_measure), !dbg !38
   tail call void @print_bool(ptr nonnull @res_result.457DE32D.0, i64 16, i1 %read_bool), !dbg !39
   ret void
 }
 
-declare i64 @___lazy_measure(i64, i64) local_unnamed_addr
+declare i64 @___future_measure(i64, i64) local_unnamed_addr
 
 declare void @___qfree(i64) local_unnamed_addr
 

--- a/qis-compiler/python/tests/snapshots/test_basic_generation/test_llvm/sol-x86_64-windows-msvc-simple_modifier/simple_modifier_x86_64-windows-msvc_sol
+++ b/qis-compiler/python/tests/snapshots/test_basic_generation/test_llvm/sol-x86_64-windows-msvc-simple_modifier/simple_modifier_x86_64-windows-msvc_sol
@@ -60,15 +60,15 @@ __hugr__.__tk2_sol_qalloc.39.exit38:              ; preds = %__barray_check_none
   %7 = tail call ptr @heap_alloc(i64 8)
   store i64 0, ptr %7, align 1
   %8 = load i64, ptr %6, align 4
-  %___lazy_measure = tail call i64 @___lazy_measure(i64 %8, i64 0), !dbg !11
+  %___future_measure = tail call i64 @___future_measure(i64 %8, i64 0), !dbg !11
   tail call void @___qfree(i64 %8), !dbg !11
-  %read_bool = tail call i1 @___read_future_bool(i64 %___lazy_measure), !dbg !11
-  tail call void @___dec_future_refcount(i64 %___lazy_measure), !dbg !11
+  %read_bool = tail call i1 @___read_future_bool(i64 %___future_measure), !dbg !11
+  tail call void @___dec_future_refcount(i64 %___future_measure), !dbg !11
   tail call void @print_bool(ptr nonnull @res_c0.7C14CD6E.0, i64 12, i1 %read_bool), !dbg !12
-  %___lazy_measure19 = tail call i64 @___lazy_measure(i64 %qalloc.i35, i64 0), !dbg !13
+  %___future_measure19 = tail call i64 @___future_measure(i64 %qalloc.i35, i64 0), !dbg !13
   tail call void @___qfree(i64 %qalloc.i35), !dbg !13
-  %read_bool21 = tail call i1 @___read_future_bool(i64 %___lazy_measure19), !dbg !13
-  tail call void @___dec_future_refcount(i64 %___lazy_measure19), !dbg !13
+  %read_bool21 = tail call i1 @___read_future_bool(i64 %___future_measure19), !dbg !13
+  tail call void @___dec_future_refcount(i64 %___future_measure19), !dbg !13
   tail call void @print_bool(ptr nonnull @res_c1.1F7A6571.0, i64 12, i1 %read_bool21), !dbg !14
   ret void
 }
@@ -78,7 +78,7 @@ declare ptr @heap_alloc(i64) local_unnamed_addr
 ; Function Attrs: noreturn
 declare void @panic(i32, ptr) local_unnamed_addr #0
 
-declare i64 @___lazy_measure(i64, i64) local_unnamed_addr
+declare i64 @___future_measure(i64, i64) local_unnamed_addr
 
 declare void @___qfree(i64) local_unnamed_addr
 

--- a/qis-compiler/python/tests/snapshots/test_qsystem_platforms/test_llvm_multiplatform/sol-aarch64-apple-darwin-flip_some/flip_some_aarch64-apple-darwin_sol
+++ b/qis-compiler/python/tests/snapshots/test_qsystem_platforms/test_llvm_multiplatform/sol-aarch64-apple-darwin-flip_some/flip_some_aarch64-apple-darwin_sol
@@ -53,31 +53,31 @@ cond_40_case_0.i44:                               ; preds = %__hugr__.__tk2_sol_
 
 __hugr__.__tk2_sol_qalloc.36.exit45:              ; preds = %__hugr__.__tk2_sol_qalloc.36.exit41
   tail call void @___reset(i64 %qalloc.i42)
-  %___lazy_measure = tail call i64 @___lazy_measure(i64 %qalloc.i, i64 0)
+  %___future_measure = tail call i64 @___future_measure(i64 %qalloc.i, i64 0)
   tail call void @___qfree(i64 %qalloc.i)
   tail call void @___rp(i64 %qalloc.i42, double 0x400921FB54442D18, double 0.000000e+00)
-  %read_bool = tail call i1 @___read_future_bool(i64 %___lazy_measure)
-  tail call void @___dec_future_refcount(i64 %___lazy_measure)
+  %read_bool = tail call i1 @___read_future_bool(i64 %___future_measure)
+  tail call void @___dec_future_refcount(i64 %___future_measure)
   tail call void @print_bool(ptr nonnull @res_c0.7C14CD6E.0, i64 12, i1 %read_bool)
-  %___lazy_measure9 = tail call i64 @___lazy_measure(i64 %qalloc.i34, i64 0)
+  %___future_measure9 = tail call i64 @___future_measure(i64 %qalloc.i34, i64 0)
   tail call void @___qfree(i64 %qalloc.i34)
-  %read_bool11 = tail call i1 @___read_future_bool(i64 %___lazy_measure9)
-  tail call void @___dec_future_refcount(i64 %___lazy_measure9)
+  %read_bool11 = tail call i1 @___read_future_bool(i64 %___future_measure9)
+  tail call void @___dec_future_refcount(i64 %___future_measure9)
   tail call void @print_bool(ptr nonnull @res_c1.1F7A6571.0, i64 12, i1 %read_bool11)
-  %___lazy_measure17 = tail call i64 @___lazy_measure(i64 %qalloc.i38, i64 0)
+  %___future_measure17 = tail call i64 @___future_measure(i64 %qalloc.i38, i64 0)
   tail call void @___qfree(i64 %qalloc.i38)
-  %read_bool19 = tail call i1 @___read_future_bool(i64 %___lazy_measure17)
-  tail call void @___dec_future_refcount(i64 %___lazy_measure17)
+  %read_bool19 = tail call i1 @___read_future_bool(i64 %___future_measure17)
+  tail call void @___dec_future_refcount(i64 %___future_measure17)
   tail call void @print_bool(ptr nonnull @res_c2.60825383.0, i64 12, i1 %read_bool19)
-  %___lazy_measure25 = tail call i64 @___lazy_measure(i64 %qalloc.i42, i64 0)
+  %___future_measure25 = tail call i64 @___future_measure(i64 %qalloc.i42, i64 0)
   tail call void @___qfree(i64 %qalloc.i42)
-  %read_bool27 = tail call i1 @___read_future_bool(i64 %___lazy_measure25)
-  tail call void @___dec_future_refcount(i64 %___lazy_measure25)
+  %read_bool27 = tail call i1 @___read_future_bool(i64 %___future_measure25)
+  tail call void @___dec_future_refcount(i64 %___future_measure25)
   tail call void @print_bool(ptr nonnull @res_c3.B223E16D.0, i64 12, i1 %read_bool27)
   ret void
 }
 
-declare i64 @___lazy_measure(i64, i64) local_unnamed_addr
+declare i64 @___future_measure(i64, i64) local_unnamed_addr
 
 declare void @___qfree(i64) local_unnamed_addr
 

--- a/qis-compiler/python/tests/snapshots/test_qsystem_platforms/test_llvm_multiplatform/sol-aarch64-apple-darwin-measure_qb_array/measure_qb_array_aarch64-apple-darwin_sol
+++ b/qis-compiler/python/tests/snapshots/test_qsystem_platforms/test_llvm_multiplatform/sol-aarch64-apple-darwin-measure_qb_array/measure_qb_array_aarch64-apple-darwin_sol
@@ -361,7 +361,7 @@ __barray_check_bounds.exit.i:                     ; preds = %__barray_check_boun
   store i64 %103, ptr %97, align 4
   %104 = getelementptr inbounds i64, ptr %.fca.0.extract62.i179.i, i64 %95
   %105 = load i64, ptr %104, align 4
-  %___lazy_measure.i = tail call i64 @___lazy_measure(i64 %105, i64 0)
+  %___future_measure.i = tail call i64 @___future_measure(i64 %105, i64 0)
   tail call void @___qfree(i64 %105)
   %106 = load i64, ptr %71, align 4
   %107 = lshr i64 %106, %"200_0.sroa.15.0178.i"
@@ -378,7 +378,7 @@ loop_body.i:                                      ; preds = %__barray_check_boun
   %111 = xor i64 %106, %110
   store i64 %111, ptr %71, align 4
   %112 = getelementptr inbounds nuw i64, ptr %70, i64 %"200_0.sroa.15.0178.i"
-  store i64 %___lazy_measure.i, ptr %112, align 4
+  store i64 %___future_measure.i, ptr %112, align 4
   %113 = extractvalue { { ptr, ptr, i64 }, i64 } %.pn159177.i, 0
   %.fca.0.extract62.i.i = extractvalue { ptr, ptr, i64 } %113, 0
   %.fca.1.extract63.i.i = extractvalue { ptr, ptr, i64 } %113, 1
@@ -705,7 +705,7 @@ declare i1 @___read_future_bool(i64) local_unnamed_addr
 
 declare void @___dec_future_refcount(i64) local_unnamed_addr
 
-declare i64 @___lazy_measure(i64, i64) local_unnamed_addr
+declare i64 @___future_measure(i64, i64) local_unnamed_addr
 
 declare void @___qfree(i64) local_unnamed_addr
 

--- a/qis-compiler/python/tests/snapshots/test_qsystem_platforms/test_llvm_multiplatform/sol-aarch64-apple-darwin-no_results/no_results_aarch64-apple-darwin_sol
+++ b/qis-compiler/python/tests/snapshots/test_qsystem_platforms/test_llvm_multiplatform/sol-aarch64-apple-darwin-no_results/no_results_aarch64-apple-darwin_sol
@@ -19,14 +19,14 @@ __hugr__.__tk2_sol_qalloc.15.exit:                ; preds = %alloca_block
   tail call void @___reset(i64 %qalloc.i)
   tail call void @___rp(i64 %qalloc.i, double 0x3FF921FB54442D18, double 0xBFF921FB54442D18)
   tail call void @___rz(i64 %qalloc.i, double 0x400921FB54442D18)
-  %___lazy_measure = tail call i64 @___lazy_measure(i64 %qalloc.i, i64 0)
+  %___future_measure = tail call i64 @___future_measure(i64 %qalloc.i, i64 0)
   tail call void @___qfree(i64 %qalloc.i)
-  %read_bool = tail call i1 @___read_future_bool(i64 %___lazy_measure)
-  tail call void @___dec_future_refcount(i64 %___lazy_measure)
+  %read_bool = tail call i1 @___read_future_bool(i64 %___future_measure)
+  tail call void @___dec_future_refcount(i64 %___future_measure)
   ret void
 }
 
-declare i64 @___lazy_measure(i64, i64) local_unnamed_addr
+declare i64 @___future_measure(i64, i64) local_unnamed_addr
 
 declare void @___qfree(i64) local_unnamed_addr
 

--- a/qis-compiler/python/tests/snapshots/test_qsystem_platforms/test_llvm_multiplatform/sol-aarch64-apple-darwin-postselect_exit/postselect_exit_aarch64-apple-darwin_sol
+++ b/qis-compiler/python/tests/snapshots/test_qsystem_platforms/test_llvm_multiplatform/sol-aarch64-apple-darwin-postselect_exit/postselect_exit_aarch64-apple-darwin_sol
@@ -21,10 +21,10 @@ __hugr__.__tk2_sol_qalloc.40.exit:                ; preds = %alloca_block
   tail call void @___reset(i64 %qalloc.i)
   tail call void @___rp(i64 %qalloc.i, double 0x3FF921FB54442D18, double 0xBFF921FB54442D18)
   tail call void @___rz(i64 %qalloc.i, double 0x400921FB54442D18)
-  %___lazy_measure = tail call i64 @___lazy_measure(i64 %qalloc.i, i64 0)
+  %___future_measure = tail call i64 @___future_measure(i64 %qalloc.i, i64 0)
   tail call void @___qfree(i64 %qalloc.i)
-  %read_bool = tail call i1 @___read_future_bool(i64 %___lazy_measure)
-  tail call void @___dec_future_refcount(i64 %___lazy_measure)
+  %read_bool = tail call i1 @___read_future_bool(i64 %___future_measure)
+  tail call void @___dec_future_refcount(i64 %___future_measure)
   br i1 %read_bool, label %1, label %0
 
 0:                                                ; preds = %__hugr__.__tk2_sol_qalloc.40.exit
@@ -36,7 +36,7 @@ __hugr__.__tk2_sol_qalloc.40.exit:                ; preds = %alloca_block
   unreachable
 }
 
-declare i64 @___lazy_measure(i64, i64) local_unnamed_addr
+declare i64 @___future_measure(i64, i64) local_unnamed_addr
 
 declare void @___qfree(i64) local_unnamed_addr
 

--- a/qis-compiler/python/tests/snapshots/test_qsystem_platforms/test_llvm_multiplatform/sol-aarch64-apple-darwin-postselect_panic/postselect_panic_aarch64-apple-darwin_sol
+++ b/qis-compiler/python/tests/snapshots/test_qsystem_platforms/test_llvm_multiplatform/sol-aarch64-apple-darwin-postselect_panic/postselect_panic_aarch64-apple-darwin_sol
@@ -21,10 +21,10 @@ __hugr__.__tk2_sol_qalloc.38.exit:                ; preds = %alloca_block
   tail call void @___reset(i64 %qalloc.i)
   tail call void @___rp(i64 %qalloc.i, double 0x3FF921FB54442D18, double 0xBFF921FB54442D18)
   tail call void @___rz(i64 %qalloc.i, double 0x400921FB54442D18)
-  %___lazy_measure = tail call i64 @___lazy_measure(i64 %qalloc.i, i64 0)
+  %___future_measure = tail call i64 @___future_measure(i64 %qalloc.i, i64 0)
   tail call void @___qfree(i64 %qalloc.i)
-  %read_bool = tail call i1 @___read_future_bool(i64 %___lazy_measure)
-  tail call void @___dec_future_refcount(i64 %___lazy_measure)
+  %read_bool = tail call i1 @___read_future_bool(i64 %___future_measure)
+  tail call void @___dec_future_refcount(i64 %___future_measure)
   br i1 %read_bool, label %1, label %0
 
 0:                                                ; preds = %__hugr__.__tk2_sol_qalloc.38.exit
@@ -36,7 +36,7 @@ __hugr__.__tk2_sol_qalloc.38.exit:                ; preds = %alloca_block
   unreachable
 }
 
-declare i64 @___lazy_measure(i64, i64) local_unnamed_addr
+declare i64 @___future_measure(i64, i64) local_unnamed_addr
 
 declare void @___qfree(i64) local_unnamed_addr
 

--- a/qis-compiler/python/tests/snapshots/test_qsystem_platforms/test_llvm_multiplatform/sol-aarch64-apple-darwin-qft_32/qft_32_aarch64-apple-darwin_sol
+++ b/qis-compiler/python/tests/snapshots/test_qsystem_platforms/test_llvm_multiplatform/sol-aarch64-apple-darwin-qft_32/qft_32_aarch64-apple-darwin_sol
@@ -170,7 +170,7 @@ __barray_check_bounds.exit.i:                     ; preds = %__barray_check_boun
   store i64 %55, ptr %49, align 4
   %56 = getelementptr inbounds i64, ptr %.fca.0.extract62.i179.i, i64 %47
   %57 = load i64, ptr %56, align 4
-  %___lazy_measure.i = tail call i64 @___lazy_measure(i64 %57, i64 0)
+  %___future_measure.i = tail call i64 @___future_measure(i64 %57, i64 0)
   tail call void @___qfree(i64 %57)
   %58 = load i64, ptr %23, align 4
   %59 = lshr i64 %58, %"341_0.sroa.15.0178.i"
@@ -187,7 +187,7 @@ loop_body.i:                                      ; preds = %__barray_check_boun
   %63 = xor i64 %58, %62
   store i64 %63, ptr %23, align 4
   %64 = getelementptr inbounds nuw i64, ptr %22, i64 %"341_0.sroa.15.0178.i"
-  store i64 %___lazy_measure.i, ptr %64, align 4
+  store i64 %___future_measure.i, ptr %64, align 4
   %65 = extractvalue { { ptr, ptr, i64 }, i64 } %.pn159177.i, 0
   %.fca.0.extract62.i.i = extractvalue { ptr, ptr, i64 } %65, 0
   %.fca.1.extract63.i.i = extractvalue { ptr, ptr, i64 } %65, 1
@@ -493,7 +493,7 @@ declare i1 @___read_future_bool(i64) local_unnamed_addr
 
 declare void @___dec_future_refcount(i64) local_unnamed_addr
 
-declare i64 @___lazy_measure(i64, i64) local_unnamed_addr
+declare i64 @___future_measure(i64, i64) local_unnamed_addr
 
 declare void @___qfree(i64) local_unnamed_addr
 

--- a/qis-compiler/python/tests/snapshots/test_qsystem_platforms/test_llvm_multiplatform/sol-aarch64-apple-darwin-rus/rus_aarch64-apple-darwin_sol
+++ b/qis-compiler/python/tests/snapshots/test_qsystem_platforms/test_llvm_multiplatform/sol-aarch64-apple-darwin-rus/rus_aarch64-apple-darwin_sol
@@ -50,10 +50,10 @@ __hugr__.__tk2_sol_qalloc.94.exit94.i:            ; preds = %__hugr__.__tk2_sol_
   tail call void @___rp(i64 %qalloc.i91.i, double 0xBFF921FB54442D18, double 0x3FF921FB54442D18)
   tail call void @___rz(i64 %qalloc.i91.i, double 0xBFF921FB54442D18)
   tail call void @___rz(i64 %qalloc.i100.i, double 0x3FE921FB54442D18)
-  %___lazy_measure.i = tail call i64 @___lazy_measure(i64 %qalloc.i100.i, i64 0)
+  %___future_measure.i = tail call i64 @___future_measure(i64 %qalloc.i100.i, i64 0)
   tail call void @___qfree(i64 %qalloc.i100.i)
-  %read_bool.i.i = tail call i1 @___read_future_bool(i64 %___lazy_measure.i)
-  tail call void @___dec_future_refcount(i64 %___lazy_measure.i)
+  %read_bool.i.i = tail call i1 @___read_future_bool(i64 %___future_measure.i)
+  tail call void @___dec_future_refcount(i64 %___future_measure.i)
   br i1 %read_bool.i.i, label %1, label %0
 
 0:                                                ; preds = %__hugr__.__tk2_sol_qalloc.94.exit94.i
@@ -74,10 +74,10 @@ __hugr__.__tk2_sol_qalloc.94.exit94.i:            ; preds = %__hugr__.__tk2_sol_
   tail call void @___rp(i64 %qalloc.i, double 0xBFF921FB54442D18, double 0x3FF921FB54442D18)
   tail call void @___rz(i64 %qalloc.i, double 0xBFF921FB54442D18)
   tail call void @___rz(i64 %qalloc.i91.i, double 0x3FE921FB54442D18)
-  %___lazy_measure52.i = tail call i64 @___lazy_measure(i64 %qalloc.i91.i, i64 0)
+  %___future_measure52.i = tail call i64 @___future_measure(i64 %qalloc.i91.i, i64 0)
   tail call void @___qfree(i64 %qalloc.i91.i)
-  %read_bool.i97.i = tail call i1 @___read_future_bool(i64 %___lazy_measure52.i)
-  tail call void @___dec_future_refcount(i64 %___lazy_measure52.i)
+  %read_bool.i97.i = tail call i1 @___read_future_bool(i64 %___future_measure52.i)
+  tail call void @___dec_future_refcount(i64 %___future_measure52.i)
   br i1 %read_bool.i97.i, label %"__hugr__.__main__.rus.<locals>.rus.17.exit", label %2
 
 2:                                                ; preds = %1
@@ -85,15 +85,15 @@ __hugr__.__tk2_sol_qalloc.94.exit94.i:            ; preds = %__hugr__.__tk2_sol_
   br label %.backedge.i
 
 "__hugr__.__main__.rus.<locals>.rus.17.exit":     ; preds = %1
-  %___lazy_measure = tail call i64 @___lazy_measure(i64 %qalloc.i, i64 0)
+  %___future_measure = tail call i64 @___future_measure(i64 %qalloc.i, i64 0)
   tail call void @___qfree(i64 %qalloc.i)
-  %read_bool = tail call i1 @___read_future_bool(i64 %___lazy_measure)
-  tail call void @___dec_future_refcount(i64 %___lazy_measure)
+  %read_bool = tail call i1 @___read_future_bool(i64 %___future_measure)
+  tail call void @___dec_future_refcount(i64 %___future_measure)
   tail call void @print_bool(ptr nonnull @res_result.457DE32D.0, i64 16, i1 %read_bool)
   ret void
 }
 
-declare i64 @___lazy_measure(i64, i64) local_unnamed_addr
+declare i64 @___future_measure(i64, i64) local_unnamed_addr
 
 declare void @___qfree(i64) local_unnamed_addr
 

--- a/qis-compiler/python/tests/snapshots/test_qsystem_platforms/test_llvm_multiplatform/sol-aarch64-apple-darwin-simple_modifier/simple_modifier_aarch64-apple-darwin_sol
+++ b/qis-compiler/python/tests/snapshots/test_qsystem_platforms/test_llvm_multiplatform/sol-aarch64-apple-darwin-simple_modifier/simple_modifier_aarch64-apple-darwin_sol
@@ -60,15 +60,15 @@ __hugr__.__tk2_sol_qalloc.39.exit38:              ; preds = %__barray_check_none
   %7 = tail call ptr @heap_alloc(i64 8)
   store i64 0, ptr %7, align 1
   %8 = load i64, ptr %6, align 4
-  %___lazy_measure = tail call i64 @___lazy_measure(i64 %8, i64 0)
+  %___future_measure = tail call i64 @___future_measure(i64 %8, i64 0)
   tail call void @___qfree(i64 %8)
-  %read_bool = tail call i1 @___read_future_bool(i64 %___lazy_measure)
-  tail call void @___dec_future_refcount(i64 %___lazy_measure)
+  %read_bool = tail call i1 @___read_future_bool(i64 %___future_measure)
+  tail call void @___dec_future_refcount(i64 %___future_measure)
   tail call void @print_bool(ptr nonnull @res_c0.7C14CD6E.0, i64 12, i1 %read_bool)
-  %___lazy_measure19 = tail call i64 @___lazy_measure(i64 %qalloc.i35, i64 0)
+  %___future_measure19 = tail call i64 @___future_measure(i64 %qalloc.i35, i64 0)
   tail call void @___qfree(i64 %qalloc.i35)
-  %read_bool21 = tail call i1 @___read_future_bool(i64 %___lazy_measure19)
-  tail call void @___dec_future_refcount(i64 %___lazy_measure19)
+  %read_bool21 = tail call i1 @___read_future_bool(i64 %___future_measure19)
+  tail call void @___dec_future_refcount(i64 %___future_measure19)
   tail call void @print_bool(ptr nonnull @res_c1.1F7A6571.0, i64 12, i1 %read_bool21)
   ret void
 }
@@ -78,7 +78,7 @@ declare ptr @heap_alloc(i64) local_unnamed_addr
 ; Function Attrs: noreturn
 declare void @panic(i32, ptr) local_unnamed_addr #0
 
-declare i64 @___lazy_measure(i64, i64) local_unnamed_addr
+declare i64 @___future_measure(i64, i64) local_unnamed_addr
 
 declare void @___qfree(i64) local_unnamed_addr
 

--- a/qis-compiler/python/tests/snapshots/test_qsystem_platforms/test_llvm_multiplatform/sol-aarch64-unknown-linux-gnu-flip_some/flip_some_aarch64-unknown-linux-gnu_sol
+++ b/qis-compiler/python/tests/snapshots/test_qsystem_platforms/test_llvm_multiplatform/sol-aarch64-unknown-linux-gnu-flip_some/flip_some_aarch64-unknown-linux-gnu_sol
@@ -53,31 +53,31 @@ cond_40_case_0.i44:                               ; preds = %__hugr__.__tk2_sol_
 
 __hugr__.__tk2_sol_qalloc.36.exit45:              ; preds = %__hugr__.__tk2_sol_qalloc.36.exit41
   tail call void @___reset(i64 %qalloc.i42)
-  %___lazy_measure = tail call i64 @___lazy_measure(i64 %qalloc.i, i64 0)
+  %___future_measure = tail call i64 @___future_measure(i64 %qalloc.i, i64 0)
   tail call void @___qfree(i64 %qalloc.i)
   tail call void @___rp(i64 %qalloc.i42, double 0x400921FB54442D18, double 0.000000e+00)
-  %read_bool = tail call i1 @___read_future_bool(i64 %___lazy_measure)
-  tail call void @___dec_future_refcount(i64 %___lazy_measure)
+  %read_bool = tail call i1 @___read_future_bool(i64 %___future_measure)
+  tail call void @___dec_future_refcount(i64 %___future_measure)
   tail call void @print_bool(ptr nonnull @res_c0.7C14CD6E.0, i64 12, i1 %read_bool)
-  %___lazy_measure9 = tail call i64 @___lazy_measure(i64 %qalloc.i34, i64 0)
+  %___future_measure9 = tail call i64 @___future_measure(i64 %qalloc.i34, i64 0)
   tail call void @___qfree(i64 %qalloc.i34)
-  %read_bool11 = tail call i1 @___read_future_bool(i64 %___lazy_measure9)
-  tail call void @___dec_future_refcount(i64 %___lazy_measure9)
+  %read_bool11 = tail call i1 @___read_future_bool(i64 %___future_measure9)
+  tail call void @___dec_future_refcount(i64 %___future_measure9)
   tail call void @print_bool(ptr nonnull @res_c1.1F7A6571.0, i64 12, i1 %read_bool11)
-  %___lazy_measure17 = tail call i64 @___lazy_measure(i64 %qalloc.i38, i64 0)
+  %___future_measure17 = tail call i64 @___future_measure(i64 %qalloc.i38, i64 0)
   tail call void @___qfree(i64 %qalloc.i38)
-  %read_bool19 = tail call i1 @___read_future_bool(i64 %___lazy_measure17)
-  tail call void @___dec_future_refcount(i64 %___lazy_measure17)
+  %read_bool19 = tail call i1 @___read_future_bool(i64 %___future_measure17)
+  tail call void @___dec_future_refcount(i64 %___future_measure17)
   tail call void @print_bool(ptr nonnull @res_c2.60825383.0, i64 12, i1 %read_bool19)
-  %___lazy_measure25 = tail call i64 @___lazy_measure(i64 %qalloc.i42, i64 0)
+  %___future_measure25 = tail call i64 @___future_measure(i64 %qalloc.i42, i64 0)
   tail call void @___qfree(i64 %qalloc.i42)
-  %read_bool27 = tail call i1 @___read_future_bool(i64 %___lazy_measure25)
-  tail call void @___dec_future_refcount(i64 %___lazy_measure25)
+  %read_bool27 = tail call i1 @___read_future_bool(i64 %___future_measure25)
+  tail call void @___dec_future_refcount(i64 %___future_measure25)
   tail call void @print_bool(ptr nonnull @res_c3.B223E16D.0, i64 12, i1 %read_bool27)
   ret void
 }
 
-declare i64 @___lazy_measure(i64, i64) local_unnamed_addr
+declare i64 @___future_measure(i64, i64) local_unnamed_addr
 
 declare void @___qfree(i64) local_unnamed_addr
 

--- a/qis-compiler/python/tests/snapshots/test_qsystem_platforms/test_llvm_multiplatform/sol-aarch64-unknown-linux-gnu-measure_qb_array/measure_qb_array_aarch64-unknown-linux-gnu_sol
+++ b/qis-compiler/python/tests/snapshots/test_qsystem_platforms/test_llvm_multiplatform/sol-aarch64-unknown-linux-gnu-measure_qb_array/measure_qb_array_aarch64-unknown-linux-gnu_sol
@@ -361,7 +361,7 @@ __barray_check_bounds.exit.i:                     ; preds = %__barray_check_boun
   store i64 %103, ptr %97, align 4
   %104 = getelementptr inbounds i64, ptr %.fca.0.extract62.i179.i, i64 %95
   %105 = load i64, ptr %104, align 4
-  %___lazy_measure.i = tail call i64 @___lazy_measure(i64 %105, i64 0)
+  %___future_measure.i = tail call i64 @___future_measure(i64 %105, i64 0)
   tail call void @___qfree(i64 %105)
   %106 = load i64, ptr %71, align 4
   %107 = lshr i64 %106, %"200_0.sroa.15.0178.i"
@@ -378,7 +378,7 @@ loop_body.i:                                      ; preds = %__barray_check_boun
   %111 = xor i64 %106, %110
   store i64 %111, ptr %71, align 4
   %112 = getelementptr inbounds nuw i64, ptr %70, i64 %"200_0.sroa.15.0178.i"
-  store i64 %___lazy_measure.i, ptr %112, align 4
+  store i64 %___future_measure.i, ptr %112, align 4
   %113 = extractvalue { { ptr, ptr, i64 }, i64 } %.pn159177.i, 0
   %.fca.0.extract62.i.i = extractvalue { ptr, ptr, i64 } %113, 0
   %.fca.1.extract63.i.i = extractvalue { ptr, ptr, i64 } %113, 1
@@ -705,7 +705,7 @@ declare i1 @___read_future_bool(i64) local_unnamed_addr
 
 declare void @___dec_future_refcount(i64) local_unnamed_addr
 
-declare i64 @___lazy_measure(i64, i64) local_unnamed_addr
+declare i64 @___future_measure(i64, i64) local_unnamed_addr
 
 declare void @___qfree(i64) local_unnamed_addr
 

--- a/qis-compiler/python/tests/snapshots/test_qsystem_platforms/test_llvm_multiplatform/sol-aarch64-unknown-linux-gnu-no_results/no_results_aarch64-unknown-linux-gnu_sol
+++ b/qis-compiler/python/tests/snapshots/test_qsystem_platforms/test_llvm_multiplatform/sol-aarch64-unknown-linux-gnu-no_results/no_results_aarch64-unknown-linux-gnu_sol
@@ -19,14 +19,14 @@ __hugr__.__tk2_sol_qalloc.15.exit:                ; preds = %alloca_block
   tail call void @___reset(i64 %qalloc.i)
   tail call void @___rp(i64 %qalloc.i, double 0x3FF921FB54442D18, double 0xBFF921FB54442D18)
   tail call void @___rz(i64 %qalloc.i, double 0x400921FB54442D18)
-  %___lazy_measure = tail call i64 @___lazy_measure(i64 %qalloc.i, i64 0)
+  %___future_measure = tail call i64 @___future_measure(i64 %qalloc.i, i64 0)
   tail call void @___qfree(i64 %qalloc.i)
-  %read_bool = tail call i1 @___read_future_bool(i64 %___lazy_measure)
-  tail call void @___dec_future_refcount(i64 %___lazy_measure)
+  %read_bool = tail call i1 @___read_future_bool(i64 %___future_measure)
+  tail call void @___dec_future_refcount(i64 %___future_measure)
   ret void
 }
 
-declare i64 @___lazy_measure(i64, i64) local_unnamed_addr
+declare i64 @___future_measure(i64, i64) local_unnamed_addr
 
 declare void @___qfree(i64) local_unnamed_addr
 

--- a/qis-compiler/python/tests/snapshots/test_qsystem_platforms/test_llvm_multiplatform/sol-aarch64-unknown-linux-gnu-postselect_exit/postselect_exit_aarch64-unknown-linux-gnu_sol
+++ b/qis-compiler/python/tests/snapshots/test_qsystem_platforms/test_llvm_multiplatform/sol-aarch64-unknown-linux-gnu-postselect_exit/postselect_exit_aarch64-unknown-linux-gnu_sol
@@ -21,10 +21,10 @@ __hugr__.__tk2_sol_qalloc.40.exit:                ; preds = %alloca_block
   tail call void @___reset(i64 %qalloc.i)
   tail call void @___rp(i64 %qalloc.i, double 0x3FF921FB54442D18, double 0xBFF921FB54442D18)
   tail call void @___rz(i64 %qalloc.i, double 0x400921FB54442D18)
-  %___lazy_measure = tail call i64 @___lazy_measure(i64 %qalloc.i, i64 0)
+  %___future_measure = tail call i64 @___future_measure(i64 %qalloc.i, i64 0)
   tail call void @___qfree(i64 %qalloc.i)
-  %read_bool = tail call i1 @___read_future_bool(i64 %___lazy_measure)
-  tail call void @___dec_future_refcount(i64 %___lazy_measure)
+  %read_bool = tail call i1 @___read_future_bool(i64 %___future_measure)
+  tail call void @___dec_future_refcount(i64 %___future_measure)
   br i1 %read_bool, label %1, label %0
 
 0:                                                ; preds = %__hugr__.__tk2_sol_qalloc.40.exit
@@ -36,7 +36,7 @@ __hugr__.__tk2_sol_qalloc.40.exit:                ; preds = %alloca_block
   unreachable
 }
 
-declare i64 @___lazy_measure(i64, i64) local_unnamed_addr
+declare i64 @___future_measure(i64, i64) local_unnamed_addr
 
 declare void @___qfree(i64) local_unnamed_addr
 

--- a/qis-compiler/python/tests/snapshots/test_qsystem_platforms/test_llvm_multiplatform/sol-aarch64-unknown-linux-gnu-postselect_panic/postselect_panic_aarch64-unknown-linux-gnu_sol
+++ b/qis-compiler/python/tests/snapshots/test_qsystem_platforms/test_llvm_multiplatform/sol-aarch64-unknown-linux-gnu-postselect_panic/postselect_panic_aarch64-unknown-linux-gnu_sol
@@ -21,10 +21,10 @@ __hugr__.__tk2_sol_qalloc.38.exit:                ; preds = %alloca_block
   tail call void @___reset(i64 %qalloc.i)
   tail call void @___rp(i64 %qalloc.i, double 0x3FF921FB54442D18, double 0xBFF921FB54442D18)
   tail call void @___rz(i64 %qalloc.i, double 0x400921FB54442D18)
-  %___lazy_measure = tail call i64 @___lazy_measure(i64 %qalloc.i, i64 0)
+  %___future_measure = tail call i64 @___future_measure(i64 %qalloc.i, i64 0)
   tail call void @___qfree(i64 %qalloc.i)
-  %read_bool = tail call i1 @___read_future_bool(i64 %___lazy_measure)
-  tail call void @___dec_future_refcount(i64 %___lazy_measure)
+  %read_bool = tail call i1 @___read_future_bool(i64 %___future_measure)
+  tail call void @___dec_future_refcount(i64 %___future_measure)
   br i1 %read_bool, label %1, label %0
 
 0:                                                ; preds = %__hugr__.__tk2_sol_qalloc.38.exit
@@ -36,7 +36,7 @@ __hugr__.__tk2_sol_qalloc.38.exit:                ; preds = %alloca_block
   unreachable
 }
 
-declare i64 @___lazy_measure(i64, i64) local_unnamed_addr
+declare i64 @___future_measure(i64, i64) local_unnamed_addr
 
 declare void @___qfree(i64) local_unnamed_addr
 

--- a/qis-compiler/python/tests/snapshots/test_qsystem_platforms/test_llvm_multiplatform/sol-aarch64-unknown-linux-gnu-qft_32/qft_32_aarch64-unknown-linux-gnu_sol
+++ b/qis-compiler/python/tests/snapshots/test_qsystem_platforms/test_llvm_multiplatform/sol-aarch64-unknown-linux-gnu-qft_32/qft_32_aarch64-unknown-linux-gnu_sol
@@ -170,7 +170,7 @@ __barray_check_bounds.exit.i:                     ; preds = %__barray_check_boun
   store i64 %55, ptr %49, align 4
   %56 = getelementptr inbounds i64, ptr %.fca.0.extract62.i179.i, i64 %47
   %57 = load i64, ptr %56, align 4
-  %___lazy_measure.i = tail call i64 @___lazy_measure(i64 %57, i64 0)
+  %___future_measure.i = tail call i64 @___future_measure(i64 %57, i64 0)
   tail call void @___qfree(i64 %57)
   %58 = load i64, ptr %23, align 4
   %59 = lshr i64 %58, %"341_0.sroa.15.0178.i"
@@ -187,7 +187,7 @@ loop_body.i:                                      ; preds = %__barray_check_boun
   %63 = xor i64 %58, %62
   store i64 %63, ptr %23, align 4
   %64 = getelementptr inbounds nuw i64, ptr %22, i64 %"341_0.sroa.15.0178.i"
-  store i64 %___lazy_measure.i, ptr %64, align 4
+  store i64 %___future_measure.i, ptr %64, align 4
   %65 = extractvalue { { ptr, ptr, i64 }, i64 } %.pn159177.i, 0
   %.fca.0.extract62.i.i = extractvalue { ptr, ptr, i64 } %65, 0
   %.fca.1.extract63.i.i = extractvalue { ptr, ptr, i64 } %65, 1
@@ -493,7 +493,7 @@ declare i1 @___read_future_bool(i64) local_unnamed_addr
 
 declare void @___dec_future_refcount(i64) local_unnamed_addr
 
-declare i64 @___lazy_measure(i64, i64) local_unnamed_addr
+declare i64 @___future_measure(i64, i64) local_unnamed_addr
 
 declare void @___qfree(i64) local_unnamed_addr
 

--- a/qis-compiler/python/tests/snapshots/test_qsystem_platforms/test_llvm_multiplatform/sol-aarch64-unknown-linux-gnu-rus/rus_aarch64-unknown-linux-gnu_sol
+++ b/qis-compiler/python/tests/snapshots/test_qsystem_platforms/test_llvm_multiplatform/sol-aarch64-unknown-linux-gnu-rus/rus_aarch64-unknown-linux-gnu_sol
@@ -50,10 +50,10 @@ __hugr__.__tk2_sol_qalloc.94.exit94.i:            ; preds = %__hugr__.__tk2_sol_
   tail call void @___rp(i64 %qalloc.i91.i, double 0xBFF921FB54442D18, double 0x3FF921FB54442D18)
   tail call void @___rz(i64 %qalloc.i91.i, double 0xBFF921FB54442D18)
   tail call void @___rz(i64 %qalloc.i100.i, double 0x3FE921FB54442D18)
-  %___lazy_measure.i = tail call i64 @___lazy_measure(i64 %qalloc.i100.i, i64 0)
+  %___future_measure.i = tail call i64 @___future_measure(i64 %qalloc.i100.i, i64 0)
   tail call void @___qfree(i64 %qalloc.i100.i)
-  %read_bool.i.i = tail call i1 @___read_future_bool(i64 %___lazy_measure.i)
-  tail call void @___dec_future_refcount(i64 %___lazy_measure.i)
+  %read_bool.i.i = tail call i1 @___read_future_bool(i64 %___future_measure.i)
+  tail call void @___dec_future_refcount(i64 %___future_measure.i)
   br i1 %read_bool.i.i, label %1, label %0
 
 0:                                                ; preds = %__hugr__.__tk2_sol_qalloc.94.exit94.i
@@ -74,10 +74,10 @@ __hugr__.__tk2_sol_qalloc.94.exit94.i:            ; preds = %__hugr__.__tk2_sol_
   tail call void @___rp(i64 %qalloc.i, double 0xBFF921FB54442D18, double 0x3FF921FB54442D18)
   tail call void @___rz(i64 %qalloc.i, double 0xBFF921FB54442D18)
   tail call void @___rz(i64 %qalloc.i91.i, double 0x3FE921FB54442D18)
-  %___lazy_measure52.i = tail call i64 @___lazy_measure(i64 %qalloc.i91.i, i64 0)
+  %___future_measure52.i = tail call i64 @___future_measure(i64 %qalloc.i91.i, i64 0)
   tail call void @___qfree(i64 %qalloc.i91.i)
-  %read_bool.i97.i = tail call i1 @___read_future_bool(i64 %___lazy_measure52.i)
-  tail call void @___dec_future_refcount(i64 %___lazy_measure52.i)
+  %read_bool.i97.i = tail call i1 @___read_future_bool(i64 %___future_measure52.i)
+  tail call void @___dec_future_refcount(i64 %___future_measure52.i)
   br i1 %read_bool.i97.i, label %"__hugr__.__main__.rus.<locals>.rus.17.exit", label %2
 
 2:                                                ; preds = %1
@@ -85,15 +85,15 @@ __hugr__.__tk2_sol_qalloc.94.exit94.i:            ; preds = %__hugr__.__tk2_sol_
   br label %.backedge.i
 
 "__hugr__.__main__.rus.<locals>.rus.17.exit":     ; preds = %1
-  %___lazy_measure = tail call i64 @___lazy_measure(i64 %qalloc.i, i64 0)
+  %___future_measure = tail call i64 @___future_measure(i64 %qalloc.i, i64 0)
   tail call void @___qfree(i64 %qalloc.i)
-  %read_bool = tail call i1 @___read_future_bool(i64 %___lazy_measure)
-  tail call void @___dec_future_refcount(i64 %___lazy_measure)
+  %read_bool = tail call i1 @___read_future_bool(i64 %___future_measure)
+  tail call void @___dec_future_refcount(i64 %___future_measure)
   tail call void @print_bool(ptr nonnull @res_result.457DE32D.0, i64 16, i1 %read_bool)
   ret void
 }
 
-declare i64 @___lazy_measure(i64, i64) local_unnamed_addr
+declare i64 @___future_measure(i64, i64) local_unnamed_addr
 
 declare void @___qfree(i64) local_unnamed_addr
 

--- a/qis-compiler/python/tests/snapshots/test_qsystem_platforms/test_llvm_multiplatform/sol-aarch64-unknown-linux-gnu-simple_modifier/simple_modifier_aarch64-unknown-linux-gnu_sol
+++ b/qis-compiler/python/tests/snapshots/test_qsystem_platforms/test_llvm_multiplatform/sol-aarch64-unknown-linux-gnu-simple_modifier/simple_modifier_aarch64-unknown-linux-gnu_sol
@@ -60,15 +60,15 @@ __hugr__.__tk2_sol_qalloc.39.exit38:              ; preds = %__barray_check_none
   %7 = tail call ptr @heap_alloc(i64 8)
   store i64 0, ptr %7, align 1
   %8 = load i64, ptr %6, align 4
-  %___lazy_measure = tail call i64 @___lazy_measure(i64 %8, i64 0)
+  %___future_measure = tail call i64 @___future_measure(i64 %8, i64 0)
   tail call void @___qfree(i64 %8)
-  %read_bool = tail call i1 @___read_future_bool(i64 %___lazy_measure)
-  tail call void @___dec_future_refcount(i64 %___lazy_measure)
+  %read_bool = tail call i1 @___read_future_bool(i64 %___future_measure)
+  tail call void @___dec_future_refcount(i64 %___future_measure)
   tail call void @print_bool(ptr nonnull @res_c0.7C14CD6E.0, i64 12, i1 %read_bool)
-  %___lazy_measure19 = tail call i64 @___lazy_measure(i64 %qalloc.i35, i64 0)
+  %___future_measure19 = tail call i64 @___future_measure(i64 %qalloc.i35, i64 0)
   tail call void @___qfree(i64 %qalloc.i35)
-  %read_bool21 = tail call i1 @___read_future_bool(i64 %___lazy_measure19)
-  tail call void @___dec_future_refcount(i64 %___lazy_measure19)
+  %read_bool21 = tail call i1 @___read_future_bool(i64 %___future_measure19)
+  tail call void @___dec_future_refcount(i64 %___future_measure19)
   tail call void @print_bool(ptr nonnull @res_c1.1F7A6571.0, i64 12, i1 %read_bool21)
   ret void
 }
@@ -78,7 +78,7 @@ declare ptr @heap_alloc(i64) local_unnamed_addr
 ; Function Attrs: noreturn
 declare void @panic(i32, ptr) local_unnamed_addr #0
 
-declare i64 @___lazy_measure(i64, i64) local_unnamed_addr
+declare i64 @___future_measure(i64, i64) local_unnamed_addr
 
 declare void @___qfree(i64) local_unnamed_addr
 

--- a/qis-compiler/python/tests/snapshots/test_qsystem_platforms/test_llvm_multiplatform/sol-x86_64-apple-darwin-flip_some/flip_some_x86_64-apple-darwin_sol
+++ b/qis-compiler/python/tests/snapshots/test_qsystem_platforms/test_llvm_multiplatform/sol-x86_64-apple-darwin-flip_some/flip_some_x86_64-apple-darwin_sol
@@ -53,31 +53,31 @@ cond_40_case_0.i44:                               ; preds = %__hugr__.__tk2_sol_
 
 __hugr__.__tk2_sol_qalloc.36.exit45:              ; preds = %__hugr__.__tk2_sol_qalloc.36.exit41
   tail call void @___reset(i64 %qalloc.i42)
-  %___lazy_measure = tail call i64 @___lazy_measure(i64 %qalloc.i, i64 0)
+  %___future_measure = tail call i64 @___future_measure(i64 %qalloc.i, i64 0)
   tail call void @___qfree(i64 %qalloc.i)
   tail call void @___rp(i64 %qalloc.i42, double 0x400921FB54442D18, double 0.000000e+00)
-  %read_bool = tail call i1 @___read_future_bool(i64 %___lazy_measure)
-  tail call void @___dec_future_refcount(i64 %___lazy_measure)
+  %read_bool = tail call i1 @___read_future_bool(i64 %___future_measure)
+  tail call void @___dec_future_refcount(i64 %___future_measure)
   tail call void @print_bool(ptr nonnull @res_c0.7C14CD6E.0, i64 12, i1 %read_bool)
-  %___lazy_measure9 = tail call i64 @___lazy_measure(i64 %qalloc.i34, i64 0)
+  %___future_measure9 = tail call i64 @___future_measure(i64 %qalloc.i34, i64 0)
   tail call void @___qfree(i64 %qalloc.i34)
-  %read_bool11 = tail call i1 @___read_future_bool(i64 %___lazy_measure9)
-  tail call void @___dec_future_refcount(i64 %___lazy_measure9)
+  %read_bool11 = tail call i1 @___read_future_bool(i64 %___future_measure9)
+  tail call void @___dec_future_refcount(i64 %___future_measure9)
   tail call void @print_bool(ptr nonnull @res_c1.1F7A6571.0, i64 12, i1 %read_bool11)
-  %___lazy_measure17 = tail call i64 @___lazy_measure(i64 %qalloc.i38, i64 0)
+  %___future_measure17 = tail call i64 @___future_measure(i64 %qalloc.i38, i64 0)
   tail call void @___qfree(i64 %qalloc.i38)
-  %read_bool19 = tail call i1 @___read_future_bool(i64 %___lazy_measure17)
-  tail call void @___dec_future_refcount(i64 %___lazy_measure17)
+  %read_bool19 = tail call i1 @___read_future_bool(i64 %___future_measure17)
+  tail call void @___dec_future_refcount(i64 %___future_measure17)
   tail call void @print_bool(ptr nonnull @res_c2.60825383.0, i64 12, i1 %read_bool19)
-  %___lazy_measure25 = tail call i64 @___lazy_measure(i64 %qalloc.i42, i64 0)
+  %___future_measure25 = tail call i64 @___future_measure(i64 %qalloc.i42, i64 0)
   tail call void @___qfree(i64 %qalloc.i42)
-  %read_bool27 = tail call i1 @___read_future_bool(i64 %___lazy_measure25)
-  tail call void @___dec_future_refcount(i64 %___lazy_measure25)
+  %read_bool27 = tail call i1 @___read_future_bool(i64 %___future_measure25)
+  tail call void @___dec_future_refcount(i64 %___future_measure25)
   tail call void @print_bool(ptr nonnull @res_c3.B223E16D.0, i64 12, i1 %read_bool27)
   ret void
 }
 
-declare i64 @___lazy_measure(i64, i64) local_unnamed_addr
+declare i64 @___future_measure(i64, i64) local_unnamed_addr
 
 declare void @___qfree(i64) local_unnamed_addr
 

--- a/qis-compiler/python/tests/snapshots/test_qsystem_platforms/test_llvm_multiplatform/sol-x86_64-apple-darwin-measure_qb_array/measure_qb_array_x86_64-apple-darwin_sol
+++ b/qis-compiler/python/tests/snapshots/test_qsystem_platforms/test_llvm_multiplatform/sol-x86_64-apple-darwin-measure_qb_array/measure_qb_array_x86_64-apple-darwin_sol
@@ -364,7 +364,7 @@ __barray_check_bounds.exit.i:                     ; preds = %__barray_check_boun
   store i64 %106, ptr %100, align 4
   %107 = getelementptr inbounds i64, ptr %.fca.0.extract62.i179.i, i64 %98
   %108 = load i64, ptr %107, align 4
-  %___lazy_measure.i = tail call i64 @___lazy_measure(i64 %108, i64 0)
+  %___future_measure.i = tail call i64 @___future_measure(i64 %108, i64 0)
   tail call void @___qfree(i64 %108)
   %109 = load i64, ptr %74, align 4
   %110 = lshr i64 %109, %"200_0.sroa.15.0178.i"
@@ -381,7 +381,7 @@ loop_body.i:                                      ; preds = %__barray_check_boun
   %114 = xor i64 %109, %113
   store i64 %114, ptr %74, align 4
   %115 = getelementptr inbounds nuw i64, ptr %73, i64 %"200_0.sroa.15.0178.i"
-  store i64 %___lazy_measure.i, ptr %115, align 4
+  store i64 %___future_measure.i, ptr %115, align 4
   %116 = extractvalue { { ptr, ptr, i64 }, i64 } %.pn159177.i, 0
   %.fca.0.extract62.i.i = extractvalue { ptr, ptr, i64 } %116, 0
   %.fca.1.extract63.i.i = extractvalue { ptr, ptr, i64 } %116, 1
@@ -554,7 +554,7 @@ declare i1 @___read_future_bool(i64) local_unnamed_addr
 
 declare void @___dec_future_refcount(i64) local_unnamed_addr
 
-declare i64 @___lazy_measure(i64, i64) local_unnamed_addr
+declare i64 @___future_measure(i64, i64) local_unnamed_addr
 
 declare void @___qfree(i64) local_unnamed_addr
 

--- a/qis-compiler/python/tests/snapshots/test_qsystem_platforms/test_llvm_multiplatform/sol-x86_64-apple-darwin-no_results/no_results_x86_64-apple-darwin_sol
+++ b/qis-compiler/python/tests/snapshots/test_qsystem_platforms/test_llvm_multiplatform/sol-x86_64-apple-darwin-no_results/no_results_x86_64-apple-darwin_sol
@@ -19,14 +19,14 @@ __hugr__.__tk2_sol_qalloc.15.exit:                ; preds = %alloca_block
   tail call void @___reset(i64 %qalloc.i)
   tail call void @___rp(i64 %qalloc.i, double 0x3FF921FB54442D18, double 0xBFF921FB54442D18)
   tail call void @___rz(i64 %qalloc.i, double 0x400921FB54442D18)
-  %___lazy_measure = tail call i64 @___lazy_measure(i64 %qalloc.i, i64 0)
+  %___future_measure = tail call i64 @___future_measure(i64 %qalloc.i, i64 0)
   tail call void @___qfree(i64 %qalloc.i)
-  %read_bool = tail call i1 @___read_future_bool(i64 %___lazy_measure)
-  tail call void @___dec_future_refcount(i64 %___lazy_measure)
+  %read_bool = tail call i1 @___read_future_bool(i64 %___future_measure)
+  tail call void @___dec_future_refcount(i64 %___future_measure)
   ret void
 }
 
-declare i64 @___lazy_measure(i64, i64) local_unnamed_addr
+declare i64 @___future_measure(i64, i64) local_unnamed_addr
 
 declare void @___qfree(i64) local_unnamed_addr
 

--- a/qis-compiler/python/tests/snapshots/test_qsystem_platforms/test_llvm_multiplatform/sol-x86_64-apple-darwin-postselect_exit/postselect_exit_x86_64-apple-darwin_sol
+++ b/qis-compiler/python/tests/snapshots/test_qsystem_platforms/test_llvm_multiplatform/sol-x86_64-apple-darwin-postselect_exit/postselect_exit_x86_64-apple-darwin_sol
@@ -21,10 +21,10 @@ __hugr__.__tk2_sol_qalloc.40.exit:                ; preds = %alloca_block
   tail call void @___reset(i64 %qalloc.i)
   tail call void @___rp(i64 %qalloc.i, double 0x3FF921FB54442D18, double 0xBFF921FB54442D18)
   tail call void @___rz(i64 %qalloc.i, double 0x400921FB54442D18)
-  %___lazy_measure = tail call i64 @___lazy_measure(i64 %qalloc.i, i64 0)
+  %___future_measure = tail call i64 @___future_measure(i64 %qalloc.i, i64 0)
   tail call void @___qfree(i64 %qalloc.i)
-  %read_bool = tail call i1 @___read_future_bool(i64 %___lazy_measure)
-  tail call void @___dec_future_refcount(i64 %___lazy_measure)
+  %read_bool = tail call i1 @___read_future_bool(i64 %___future_measure)
+  tail call void @___dec_future_refcount(i64 %___future_measure)
   br i1 %read_bool, label %1, label %0
 
 0:                                                ; preds = %__hugr__.__tk2_sol_qalloc.40.exit
@@ -36,7 +36,7 @@ __hugr__.__tk2_sol_qalloc.40.exit:                ; preds = %alloca_block
   unreachable
 }
 
-declare i64 @___lazy_measure(i64, i64) local_unnamed_addr
+declare i64 @___future_measure(i64, i64) local_unnamed_addr
 
 declare void @___qfree(i64) local_unnamed_addr
 

--- a/qis-compiler/python/tests/snapshots/test_qsystem_platforms/test_llvm_multiplatform/sol-x86_64-apple-darwin-postselect_panic/postselect_panic_x86_64-apple-darwin_sol
+++ b/qis-compiler/python/tests/snapshots/test_qsystem_platforms/test_llvm_multiplatform/sol-x86_64-apple-darwin-postselect_panic/postselect_panic_x86_64-apple-darwin_sol
@@ -21,10 +21,10 @@ __hugr__.__tk2_sol_qalloc.38.exit:                ; preds = %alloca_block
   tail call void @___reset(i64 %qalloc.i)
   tail call void @___rp(i64 %qalloc.i, double 0x3FF921FB54442D18, double 0xBFF921FB54442D18)
   tail call void @___rz(i64 %qalloc.i, double 0x400921FB54442D18)
-  %___lazy_measure = tail call i64 @___lazy_measure(i64 %qalloc.i, i64 0)
+  %___future_measure = tail call i64 @___future_measure(i64 %qalloc.i, i64 0)
   tail call void @___qfree(i64 %qalloc.i)
-  %read_bool = tail call i1 @___read_future_bool(i64 %___lazy_measure)
-  tail call void @___dec_future_refcount(i64 %___lazy_measure)
+  %read_bool = tail call i1 @___read_future_bool(i64 %___future_measure)
+  tail call void @___dec_future_refcount(i64 %___future_measure)
   br i1 %read_bool, label %1, label %0
 
 0:                                                ; preds = %__hugr__.__tk2_sol_qalloc.38.exit
@@ -36,7 +36,7 @@ __hugr__.__tk2_sol_qalloc.38.exit:                ; preds = %alloca_block
   unreachable
 }
 
-declare i64 @___lazy_measure(i64, i64) local_unnamed_addr
+declare i64 @___future_measure(i64, i64) local_unnamed_addr
 
 declare void @___qfree(i64) local_unnamed_addr
 

--- a/qis-compiler/python/tests/snapshots/test_qsystem_platforms/test_llvm_multiplatform/sol-x86_64-apple-darwin-qft_32/qft_32_x86_64-apple-darwin_sol
+++ b/qis-compiler/python/tests/snapshots/test_qsystem_platforms/test_llvm_multiplatform/sol-x86_64-apple-darwin-qft_32/qft_32_x86_64-apple-darwin_sol
@@ -170,7 +170,7 @@ __barray_check_bounds.exit.i:                     ; preds = %__barray_check_boun
   store i64 %55, ptr %49, align 4
   %56 = getelementptr inbounds i64, ptr %.fca.0.extract62.i179.i, i64 %47
   %57 = load i64, ptr %56, align 4
-  %___lazy_measure.i = tail call i64 @___lazy_measure(i64 %57, i64 0)
+  %___future_measure.i = tail call i64 @___future_measure(i64 %57, i64 0)
   tail call void @___qfree(i64 %57)
   %58 = load i64, ptr %23, align 4
   %59 = lshr i64 %58, %"341_0.sroa.15.0178.i"
@@ -187,7 +187,7 @@ loop_body.i:                                      ; preds = %__barray_check_boun
   %63 = xor i64 %58, %62
   store i64 %63, ptr %23, align 4
   %64 = getelementptr inbounds nuw i64, ptr %22, i64 %"341_0.sroa.15.0178.i"
-  store i64 %___lazy_measure.i, ptr %64, align 4
+  store i64 %___future_measure.i, ptr %64, align 4
   %65 = extractvalue { { ptr, ptr, i64 }, i64 } %.pn159177.i, 0
   %.fca.0.extract62.i.i = extractvalue { ptr, ptr, i64 } %65, 0
   %.fca.1.extract63.i.i = extractvalue { ptr, ptr, i64 } %65, 1
@@ -493,7 +493,7 @@ declare i1 @___read_future_bool(i64) local_unnamed_addr
 
 declare void @___dec_future_refcount(i64) local_unnamed_addr
 
-declare i64 @___lazy_measure(i64, i64) local_unnamed_addr
+declare i64 @___future_measure(i64, i64) local_unnamed_addr
 
 declare void @___qfree(i64) local_unnamed_addr
 

--- a/qis-compiler/python/tests/snapshots/test_qsystem_platforms/test_llvm_multiplatform/sol-x86_64-apple-darwin-rus/rus_x86_64-apple-darwin_sol
+++ b/qis-compiler/python/tests/snapshots/test_qsystem_platforms/test_llvm_multiplatform/sol-x86_64-apple-darwin-rus/rus_x86_64-apple-darwin_sol
@@ -50,10 +50,10 @@ __hugr__.__tk2_sol_qalloc.94.exit94.i:            ; preds = %__hugr__.__tk2_sol_
   tail call void @___rp(i64 %qalloc.i91.i, double 0xBFF921FB54442D18, double 0x3FF921FB54442D18)
   tail call void @___rz(i64 %qalloc.i91.i, double 0xBFF921FB54442D18)
   tail call void @___rz(i64 %qalloc.i100.i, double 0x3FE921FB54442D18)
-  %___lazy_measure.i = tail call i64 @___lazy_measure(i64 %qalloc.i100.i, i64 0)
+  %___future_measure.i = tail call i64 @___future_measure(i64 %qalloc.i100.i, i64 0)
   tail call void @___qfree(i64 %qalloc.i100.i)
-  %read_bool.i.i = tail call i1 @___read_future_bool(i64 %___lazy_measure.i)
-  tail call void @___dec_future_refcount(i64 %___lazy_measure.i)
+  %read_bool.i.i = tail call i1 @___read_future_bool(i64 %___future_measure.i)
+  tail call void @___dec_future_refcount(i64 %___future_measure.i)
   br i1 %read_bool.i.i, label %1, label %0
 
 0:                                                ; preds = %__hugr__.__tk2_sol_qalloc.94.exit94.i
@@ -74,10 +74,10 @@ __hugr__.__tk2_sol_qalloc.94.exit94.i:            ; preds = %__hugr__.__tk2_sol_
   tail call void @___rp(i64 %qalloc.i, double 0xBFF921FB54442D18, double 0x3FF921FB54442D18)
   tail call void @___rz(i64 %qalloc.i, double 0xBFF921FB54442D18)
   tail call void @___rz(i64 %qalloc.i91.i, double 0x3FE921FB54442D18)
-  %___lazy_measure52.i = tail call i64 @___lazy_measure(i64 %qalloc.i91.i, i64 0)
+  %___future_measure52.i = tail call i64 @___future_measure(i64 %qalloc.i91.i, i64 0)
   tail call void @___qfree(i64 %qalloc.i91.i)
-  %read_bool.i97.i = tail call i1 @___read_future_bool(i64 %___lazy_measure52.i)
-  tail call void @___dec_future_refcount(i64 %___lazy_measure52.i)
+  %read_bool.i97.i = tail call i1 @___read_future_bool(i64 %___future_measure52.i)
+  tail call void @___dec_future_refcount(i64 %___future_measure52.i)
   br i1 %read_bool.i97.i, label %"__hugr__.__main__.rus.<locals>.rus.17.exit", label %2
 
 2:                                                ; preds = %1
@@ -85,15 +85,15 @@ __hugr__.__tk2_sol_qalloc.94.exit94.i:            ; preds = %__hugr__.__tk2_sol_
   br label %.backedge.i
 
 "__hugr__.__main__.rus.<locals>.rus.17.exit":     ; preds = %1
-  %___lazy_measure = tail call i64 @___lazy_measure(i64 %qalloc.i, i64 0)
+  %___future_measure = tail call i64 @___future_measure(i64 %qalloc.i, i64 0)
   tail call void @___qfree(i64 %qalloc.i)
-  %read_bool = tail call i1 @___read_future_bool(i64 %___lazy_measure)
-  tail call void @___dec_future_refcount(i64 %___lazy_measure)
+  %read_bool = tail call i1 @___read_future_bool(i64 %___future_measure)
+  tail call void @___dec_future_refcount(i64 %___future_measure)
   tail call void @print_bool(ptr nonnull @res_result.457DE32D.0, i64 16, i1 %read_bool)
   ret void
 }
 
-declare i64 @___lazy_measure(i64, i64) local_unnamed_addr
+declare i64 @___future_measure(i64, i64) local_unnamed_addr
 
 declare void @___qfree(i64) local_unnamed_addr
 

--- a/qis-compiler/python/tests/snapshots/test_qsystem_platforms/test_llvm_multiplatform/sol-x86_64-apple-darwin-simple_modifier/simple_modifier_x86_64-apple-darwin_sol
+++ b/qis-compiler/python/tests/snapshots/test_qsystem_platforms/test_llvm_multiplatform/sol-x86_64-apple-darwin-simple_modifier/simple_modifier_x86_64-apple-darwin_sol
@@ -60,15 +60,15 @@ __hugr__.__tk2_sol_qalloc.39.exit38:              ; preds = %__barray_check_none
   %7 = tail call ptr @heap_alloc(i64 8)
   store i64 0, ptr %7, align 1
   %8 = load i64, ptr %6, align 4
-  %___lazy_measure = tail call i64 @___lazy_measure(i64 %8, i64 0)
+  %___future_measure = tail call i64 @___future_measure(i64 %8, i64 0)
   tail call void @___qfree(i64 %8)
-  %read_bool = tail call i1 @___read_future_bool(i64 %___lazy_measure)
-  tail call void @___dec_future_refcount(i64 %___lazy_measure)
+  %read_bool = tail call i1 @___read_future_bool(i64 %___future_measure)
+  tail call void @___dec_future_refcount(i64 %___future_measure)
   tail call void @print_bool(ptr nonnull @res_c0.7C14CD6E.0, i64 12, i1 %read_bool)
-  %___lazy_measure19 = tail call i64 @___lazy_measure(i64 %qalloc.i35, i64 0)
+  %___future_measure19 = tail call i64 @___future_measure(i64 %qalloc.i35, i64 0)
   tail call void @___qfree(i64 %qalloc.i35)
-  %read_bool21 = tail call i1 @___read_future_bool(i64 %___lazy_measure19)
-  tail call void @___dec_future_refcount(i64 %___lazy_measure19)
+  %read_bool21 = tail call i1 @___read_future_bool(i64 %___future_measure19)
+  tail call void @___dec_future_refcount(i64 %___future_measure19)
   tail call void @print_bool(ptr nonnull @res_c1.1F7A6571.0, i64 12, i1 %read_bool21)
   ret void
 }
@@ -78,7 +78,7 @@ declare ptr @heap_alloc(i64) local_unnamed_addr
 ; Function Attrs: noreturn
 declare void @panic(i32, ptr) local_unnamed_addr #0
 
-declare i64 @___lazy_measure(i64, i64) local_unnamed_addr
+declare i64 @___future_measure(i64, i64) local_unnamed_addr
 
 declare void @___qfree(i64) local_unnamed_addr
 

--- a/qis-compiler/python/tests/snapshots/test_qsystem_platforms/test_llvm_multiplatform/sol-x86_64-unknown-linux-gnu-flip_some/flip_some_x86_64-unknown-linux-gnu_sol
+++ b/qis-compiler/python/tests/snapshots/test_qsystem_platforms/test_llvm_multiplatform/sol-x86_64-unknown-linux-gnu-flip_some/flip_some_x86_64-unknown-linux-gnu_sol
@@ -53,31 +53,31 @@ cond_40_case_0.i44:                               ; preds = %__hugr__.__tk2_sol_
 
 __hugr__.__tk2_sol_qalloc.36.exit45:              ; preds = %__hugr__.__tk2_sol_qalloc.36.exit41
   tail call void @___reset(i64 %qalloc.i42)
-  %___lazy_measure = tail call i64 @___lazy_measure(i64 %qalloc.i, i64 0)
+  %___future_measure = tail call i64 @___future_measure(i64 %qalloc.i, i64 0)
   tail call void @___qfree(i64 %qalloc.i)
   tail call void @___rp(i64 %qalloc.i42, double 0x400921FB54442D18, double 0.000000e+00)
-  %read_bool = tail call i1 @___read_future_bool(i64 %___lazy_measure)
-  tail call void @___dec_future_refcount(i64 %___lazy_measure)
+  %read_bool = tail call i1 @___read_future_bool(i64 %___future_measure)
+  tail call void @___dec_future_refcount(i64 %___future_measure)
   tail call void @print_bool(ptr nonnull @res_c0.7C14CD6E.0, i64 12, i1 %read_bool)
-  %___lazy_measure9 = tail call i64 @___lazy_measure(i64 %qalloc.i34, i64 0)
+  %___future_measure9 = tail call i64 @___future_measure(i64 %qalloc.i34, i64 0)
   tail call void @___qfree(i64 %qalloc.i34)
-  %read_bool11 = tail call i1 @___read_future_bool(i64 %___lazy_measure9)
-  tail call void @___dec_future_refcount(i64 %___lazy_measure9)
+  %read_bool11 = tail call i1 @___read_future_bool(i64 %___future_measure9)
+  tail call void @___dec_future_refcount(i64 %___future_measure9)
   tail call void @print_bool(ptr nonnull @res_c1.1F7A6571.0, i64 12, i1 %read_bool11)
-  %___lazy_measure17 = tail call i64 @___lazy_measure(i64 %qalloc.i38, i64 0)
+  %___future_measure17 = tail call i64 @___future_measure(i64 %qalloc.i38, i64 0)
   tail call void @___qfree(i64 %qalloc.i38)
-  %read_bool19 = tail call i1 @___read_future_bool(i64 %___lazy_measure17)
-  tail call void @___dec_future_refcount(i64 %___lazy_measure17)
+  %read_bool19 = tail call i1 @___read_future_bool(i64 %___future_measure17)
+  tail call void @___dec_future_refcount(i64 %___future_measure17)
   tail call void @print_bool(ptr nonnull @res_c2.60825383.0, i64 12, i1 %read_bool19)
-  %___lazy_measure25 = tail call i64 @___lazy_measure(i64 %qalloc.i42, i64 0)
+  %___future_measure25 = tail call i64 @___future_measure(i64 %qalloc.i42, i64 0)
   tail call void @___qfree(i64 %qalloc.i42)
-  %read_bool27 = tail call i1 @___read_future_bool(i64 %___lazy_measure25)
-  tail call void @___dec_future_refcount(i64 %___lazy_measure25)
+  %read_bool27 = tail call i1 @___read_future_bool(i64 %___future_measure25)
+  tail call void @___dec_future_refcount(i64 %___future_measure25)
   tail call void @print_bool(ptr nonnull @res_c3.B223E16D.0, i64 12, i1 %read_bool27)
   ret void
 }
 
-declare i64 @___lazy_measure(i64, i64) local_unnamed_addr
+declare i64 @___future_measure(i64, i64) local_unnamed_addr
 
 declare void @___qfree(i64) local_unnamed_addr
 

--- a/qis-compiler/python/tests/snapshots/test_qsystem_platforms/test_llvm_multiplatform/sol-x86_64-unknown-linux-gnu-measure_qb_array/measure_qb_array_x86_64-unknown-linux-gnu_sol
+++ b/qis-compiler/python/tests/snapshots/test_qsystem_platforms/test_llvm_multiplatform/sol-x86_64-unknown-linux-gnu-measure_qb_array/measure_qb_array_x86_64-unknown-linux-gnu_sol
@@ -364,7 +364,7 @@ __barray_check_bounds.exit.i:                     ; preds = %__barray_check_boun
   store i64 %106, ptr %100, align 4
   %107 = getelementptr inbounds i64, ptr %.fca.0.extract62.i179.i, i64 %98
   %108 = load i64, ptr %107, align 4
-  %___lazy_measure.i = tail call i64 @___lazy_measure(i64 %108, i64 0)
+  %___future_measure.i = tail call i64 @___future_measure(i64 %108, i64 0)
   tail call void @___qfree(i64 %108)
   %109 = load i64, ptr %74, align 4
   %110 = lshr i64 %109, %"200_0.sroa.15.0178.i"
@@ -381,7 +381,7 @@ loop_body.i:                                      ; preds = %__barray_check_boun
   %114 = xor i64 %109, %113
   store i64 %114, ptr %74, align 4
   %115 = getelementptr inbounds nuw i64, ptr %73, i64 %"200_0.sroa.15.0178.i"
-  store i64 %___lazy_measure.i, ptr %115, align 4
+  store i64 %___future_measure.i, ptr %115, align 4
   %116 = extractvalue { { ptr, ptr, i64 }, i64 } %.pn159177.i, 0
   %.fca.0.extract62.i.i = extractvalue { ptr, ptr, i64 } %116, 0
   %.fca.1.extract63.i.i = extractvalue { ptr, ptr, i64 } %116, 1
@@ -554,7 +554,7 @@ declare i1 @___read_future_bool(i64) local_unnamed_addr
 
 declare void @___dec_future_refcount(i64) local_unnamed_addr
 
-declare i64 @___lazy_measure(i64, i64) local_unnamed_addr
+declare i64 @___future_measure(i64, i64) local_unnamed_addr
 
 declare void @___qfree(i64) local_unnamed_addr
 

--- a/qis-compiler/python/tests/snapshots/test_qsystem_platforms/test_llvm_multiplatform/sol-x86_64-unknown-linux-gnu-no_results/no_results_x86_64-unknown-linux-gnu_sol
+++ b/qis-compiler/python/tests/snapshots/test_qsystem_platforms/test_llvm_multiplatform/sol-x86_64-unknown-linux-gnu-no_results/no_results_x86_64-unknown-linux-gnu_sol
@@ -19,14 +19,14 @@ __hugr__.__tk2_sol_qalloc.15.exit:                ; preds = %alloca_block
   tail call void @___reset(i64 %qalloc.i)
   tail call void @___rp(i64 %qalloc.i, double 0x3FF921FB54442D18, double 0xBFF921FB54442D18)
   tail call void @___rz(i64 %qalloc.i, double 0x400921FB54442D18)
-  %___lazy_measure = tail call i64 @___lazy_measure(i64 %qalloc.i, i64 0)
+  %___future_measure = tail call i64 @___future_measure(i64 %qalloc.i, i64 0)
   tail call void @___qfree(i64 %qalloc.i)
-  %read_bool = tail call i1 @___read_future_bool(i64 %___lazy_measure)
-  tail call void @___dec_future_refcount(i64 %___lazy_measure)
+  %read_bool = tail call i1 @___read_future_bool(i64 %___future_measure)
+  tail call void @___dec_future_refcount(i64 %___future_measure)
   ret void
 }
 
-declare i64 @___lazy_measure(i64, i64) local_unnamed_addr
+declare i64 @___future_measure(i64, i64) local_unnamed_addr
 
 declare void @___qfree(i64) local_unnamed_addr
 

--- a/qis-compiler/python/tests/snapshots/test_qsystem_platforms/test_llvm_multiplatform/sol-x86_64-unknown-linux-gnu-postselect_exit/postselect_exit_x86_64-unknown-linux-gnu_sol
+++ b/qis-compiler/python/tests/snapshots/test_qsystem_platforms/test_llvm_multiplatform/sol-x86_64-unknown-linux-gnu-postselect_exit/postselect_exit_x86_64-unknown-linux-gnu_sol
@@ -21,10 +21,10 @@ __hugr__.__tk2_sol_qalloc.40.exit:                ; preds = %alloca_block
   tail call void @___reset(i64 %qalloc.i)
   tail call void @___rp(i64 %qalloc.i, double 0x3FF921FB54442D18, double 0xBFF921FB54442D18)
   tail call void @___rz(i64 %qalloc.i, double 0x400921FB54442D18)
-  %___lazy_measure = tail call i64 @___lazy_measure(i64 %qalloc.i, i64 0)
+  %___future_measure = tail call i64 @___future_measure(i64 %qalloc.i, i64 0)
   tail call void @___qfree(i64 %qalloc.i)
-  %read_bool = tail call i1 @___read_future_bool(i64 %___lazy_measure)
-  tail call void @___dec_future_refcount(i64 %___lazy_measure)
+  %read_bool = tail call i1 @___read_future_bool(i64 %___future_measure)
+  tail call void @___dec_future_refcount(i64 %___future_measure)
   br i1 %read_bool, label %1, label %0
 
 0:                                                ; preds = %__hugr__.__tk2_sol_qalloc.40.exit
@@ -36,7 +36,7 @@ __hugr__.__tk2_sol_qalloc.40.exit:                ; preds = %alloca_block
   unreachable
 }
 
-declare i64 @___lazy_measure(i64, i64) local_unnamed_addr
+declare i64 @___future_measure(i64, i64) local_unnamed_addr
 
 declare void @___qfree(i64) local_unnamed_addr
 

--- a/qis-compiler/python/tests/snapshots/test_qsystem_platforms/test_llvm_multiplatform/sol-x86_64-unknown-linux-gnu-postselect_panic/postselect_panic_x86_64-unknown-linux-gnu_sol
+++ b/qis-compiler/python/tests/snapshots/test_qsystem_platforms/test_llvm_multiplatform/sol-x86_64-unknown-linux-gnu-postselect_panic/postselect_panic_x86_64-unknown-linux-gnu_sol
@@ -21,10 +21,10 @@ __hugr__.__tk2_sol_qalloc.38.exit:                ; preds = %alloca_block
   tail call void @___reset(i64 %qalloc.i)
   tail call void @___rp(i64 %qalloc.i, double 0x3FF921FB54442D18, double 0xBFF921FB54442D18)
   tail call void @___rz(i64 %qalloc.i, double 0x400921FB54442D18)
-  %___lazy_measure = tail call i64 @___lazy_measure(i64 %qalloc.i, i64 0)
+  %___future_measure = tail call i64 @___future_measure(i64 %qalloc.i, i64 0)
   tail call void @___qfree(i64 %qalloc.i)
-  %read_bool = tail call i1 @___read_future_bool(i64 %___lazy_measure)
-  tail call void @___dec_future_refcount(i64 %___lazy_measure)
+  %read_bool = tail call i1 @___read_future_bool(i64 %___future_measure)
+  tail call void @___dec_future_refcount(i64 %___future_measure)
   br i1 %read_bool, label %1, label %0
 
 0:                                                ; preds = %__hugr__.__tk2_sol_qalloc.38.exit
@@ -36,7 +36,7 @@ __hugr__.__tk2_sol_qalloc.38.exit:                ; preds = %alloca_block
   unreachable
 }
 
-declare i64 @___lazy_measure(i64, i64) local_unnamed_addr
+declare i64 @___future_measure(i64, i64) local_unnamed_addr
 
 declare void @___qfree(i64) local_unnamed_addr
 

--- a/qis-compiler/python/tests/snapshots/test_qsystem_platforms/test_llvm_multiplatform/sol-x86_64-unknown-linux-gnu-qft_32/qft_32_x86_64-unknown-linux-gnu_sol
+++ b/qis-compiler/python/tests/snapshots/test_qsystem_platforms/test_llvm_multiplatform/sol-x86_64-unknown-linux-gnu-qft_32/qft_32_x86_64-unknown-linux-gnu_sol
@@ -170,7 +170,7 @@ __barray_check_bounds.exit.i:                     ; preds = %__barray_check_boun
   store i64 %55, ptr %49, align 4
   %56 = getelementptr inbounds i64, ptr %.fca.0.extract62.i179.i, i64 %47
   %57 = load i64, ptr %56, align 4
-  %___lazy_measure.i = tail call i64 @___lazy_measure(i64 %57, i64 0)
+  %___future_measure.i = tail call i64 @___future_measure(i64 %57, i64 0)
   tail call void @___qfree(i64 %57)
   %58 = load i64, ptr %23, align 4
   %59 = lshr i64 %58, %"341_0.sroa.15.0178.i"
@@ -187,7 +187,7 @@ loop_body.i:                                      ; preds = %__barray_check_boun
   %63 = xor i64 %58, %62
   store i64 %63, ptr %23, align 4
   %64 = getelementptr inbounds nuw i64, ptr %22, i64 %"341_0.sroa.15.0178.i"
-  store i64 %___lazy_measure.i, ptr %64, align 4
+  store i64 %___future_measure.i, ptr %64, align 4
   %65 = extractvalue { { ptr, ptr, i64 }, i64 } %.pn159177.i, 0
   %.fca.0.extract62.i.i = extractvalue { ptr, ptr, i64 } %65, 0
   %.fca.1.extract63.i.i = extractvalue { ptr, ptr, i64 } %65, 1
@@ -493,7 +493,7 @@ declare i1 @___read_future_bool(i64) local_unnamed_addr
 
 declare void @___dec_future_refcount(i64) local_unnamed_addr
 
-declare i64 @___lazy_measure(i64, i64) local_unnamed_addr
+declare i64 @___future_measure(i64, i64) local_unnamed_addr
 
 declare void @___qfree(i64) local_unnamed_addr
 

--- a/qis-compiler/python/tests/snapshots/test_qsystem_platforms/test_llvm_multiplatform/sol-x86_64-unknown-linux-gnu-rus/rus_x86_64-unknown-linux-gnu_sol
+++ b/qis-compiler/python/tests/snapshots/test_qsystem_platforms/test_llvm_multiplatform/sol-x86_64-unknown-linux-gnu-rus/rus_x86_64-unknown-linux-gnu_sol
@@ -50,10 +50,10 @@ __hugr__.__tk2_sol_qalloc.94.exit94.i:            ; preds = %__hugr__.__tk2_sol_
   tail call void @___rp(i64 %qalloc.i91.i, double 0xBFF921FB54442D18, double 0x3FF921FB54442D18)
   tail call void @___rz(i64 %qalloc.i91.i, double 0xBFF921FB54442D18)
   tail call void @___rz(i64 %qalloc.i100.i, double 0x3FE921FB54442D18)
-  %___lazy_measure.i = tail call i64 @___lazy_measure(i64 %qalloc.i100.i, i64 0)
+  %___future_measure.i = tail call i64 @___future_measure(i64 %qalloc.i100.i, i64 0)
   tail call void @___qfree(i64 %qalloc.i100.i)
-  %read_bool.i.i = tail call i1 @___read_future_bool(i64 %___lazy_measure.i)
-  tail call void @___dec_future_refcount(i64 %___lazy_measure.i)
+  %read_bool.i.i = tail call i1 @___read_future_bool(i64 %___future_measure.i)
+  tail call void @___dec_future_refcount(i64 %___future_measure.i)
   br i1 %read_bool.i.i, label %1, label %0
 
 0:                                                ; preds = %__hugr__.__tk2_sol_qalloc.94.exit94.i
@@ -74,10 +74,10 @@ __hugr__.__tk2_sol_qalloc.94.exit94.i:            ; preds = %__hugr__.__tk2_sol_
   tail call void @___rp(i64 %qalloc.i, double 0xBFF921FB54442D18, double 0x3FF921FB54442D18)
   tail call void @___rz(i64 %qalloc.i, double 0xBFF921FB54442D18)
   tail call void @___rz(i64 %qalloc.i91.i, double 0x3FE921FB54442D18)
-  %___lazy_measure52.i = tail call i64 @___lazy_measure(i64 %qalloc.i91.i, i64 0)
+  %___future_measure52.i = tail call i64 @___future_measure(i64 %qalloc.i91.i, i64 0)
   tail call void @___qfree(i64 %qalloc.i91.i)
-  %read_bool.i97.i = tail call i1 @___read_future_bool(i64 %___lazy_measure52.i)
-  tail call void @___dec_future_refcount(i64 %___lazy_measure52.i)
+  %read_bool.i97.i = tail call i1 @___read_future_bool(i64 %___future_measure52.i)
+  tail call void @___dec_future_refcount(i64 %___future_measure52.i)
   br i1 %read_bool.i97.i, label %"__hugr__.__main__.rus.<locals>.rus.17.exit", label %2
 
 2:                                                ; preds = %1
@@ -85,15 +85,15 @@ __hugr__.__tk2_sol_qalloc.94.exit94.i:            ; preds = %__hugr__.__tk2_sol_
   br label %.backedge.i
 
 "__hugr__.__main__.rus.<locals>.rus.17.exit":     ; preds = %1
-  %___lazy_measure = tail call i64 @___lazy_measure(i64 %qalloc.i, i64 0)
+  %___future_measure = tail call i64 @___future_measure(i64 %qalloc.i, i64 0)
   tail call void @___qfree(i64 %qalloc.i)
-  %read_bool = tail call i1 @___read_future_bool(i64 %___lazy_measure)
-  tail call void @___dec_future_refcount(i64 %___lazy_measure)
+  %read_bool = tail call i1 @___read_future_bool(i64 %___future_measure)
+  tail call void @___dec_future_refcount(i64 %___future_measure)
   tail call void @print_bool(ptr nonnull @res_result.457DE32D.0, i64 16, i1 %read_bool)
   ret void
 }
 
-declare i64 @___lazy_measure(i64, i64) local_unnamed_addr
+declare i64 @___future_measure(i64, i64) local_unnamed_addr
 
 declare void @___qfree(i64) local_unnamed_addr
 

--- a/qis-compiler/python/tests/snapshots/test_qsystem_platforms/test_llvm_multiplatform/sol-x86_64-unknown-linux-gnu-simple_modifier/simple_modifier_x86_64-unknown-linux-gnu_sol
+++ b/qis-compiler/python/tests/snapshots/test_qsystem_platforms/test_llvm_multiplatform/sol-x86_64-unknown-linux-gnu-simple_modifier/simple_modifier_x86_64-unknown-linux-gnu_sol
@@ -60,15 +60,15 @@ __hugr__.__tk2_sol_qalloc.39.exit38:              ; preds = %__barray_check_none
   %7 = tail call ptr @heap_alloc(i64 8)
   store i64 0, ptr %7, align 1
   %8 = load i64, ptr %6, align 4
-  %___lazy_measure = tail call i64 @___lazy_measure(i64 %8, i64 0)
+  %___future_measure = tail call i64 @___future_measure(i64 %8, i64 0)
   tail call void @___qfree(i64 %8)
-  %read_bool = tail call i1 @___read_future_bool(i64 %___lazy_measure)
-  tail call void @___dec_future_refcount(i64 %___lazy_measure)
+  %read_bool = tail call i1 @___read_future_bool(i64 %___future_measure)
+  tail call void @___dec_future_refcount(i64 %___future_measure)
   tail call void @print_bool(ptr nonnull @res_c0.7C14CD6E.0, i64 12, i1 %read_bool)
-  %___lazy_measure19 = tail call i64 @___lazy_measure(i64 %qalloc.i35, i64 0)
+  %___future_measure19 = tail call i64 @___future_measure(i64 %qalloc.i35, i64 0)
   tail call void @___qfree(i64 %qalloc.i35)
-  %read_bool21 = tail call i1 @___read_future_bool(i64 %___lazy_measure19)
-  tail call void @___dec_future_refcount(i64 %___lazy_measure19)
+  %read_bool21 = tail call i1 @___read_future_bool(i64 %___future_measure19)
+  tail call void @___dec_future_refcount(i64 %___future_measure19)
   tail call void @print_bool(ptr nonnull @res_c1.1F7A6571.0, i64 12, i1 %read_bool21)
   ret void
 }
@@ -78,7 +78,7 @@ declare ptr @heap_alloc(i64) local_unnamed_addr
 ; Function Attrs: noreturn
 declare void @panic(i32, ptr) local_unnamed_addr #0
 
-declare i64 @___lazy_measure(i64, i64) local_unnamed_addr
+declare i64 @___future_measure(i64, i64) local_unnamed_addr
 
 declare void @___qfree(i64) local_unnamed_addr
 

--- a/qis-compiler/python/tests/snapshots/test_qsystem_platforms/test_llvm_multiplatform/sol-x86_64-windows-msvc-flip_some/flip_some_x86_64-windows-msvc_sol
+++ b/qis-compiler/python/tests/snapshots/test_qsystem_platforms/test_llvm_multiplatform/sol-x86_64-windows-msvc-flip_some/flip_some_x86_64-windows-msvc_sol
@@ -53,31 +53,31 @@ cond_40_case_0.i44:                               ; preds = %__hugr__.__tk2_sol_
 
 __hugr__.__tk2_sol_qalloc.36.exit45:              ; preds = %__hugr__.__tk2_sol_qalloc.36.exit41
   tail call void @___reset(i64 %qalloc.i42)
-  %___lazy_measure = tail call i64 @___lazy_measure(i64 %qalloc.i, i64 0)
+  %___future_measure = tail call i64 @___future_measure(i64 %qalloc.i, i64 0)
   tail call void @___qfree(i64 %qalloc.i)
   tail call void @___rp(i64 %qalloc.i42, double 0x400921FB54442D18, double 0.000000e+00)
-  %read_bool = tail call i1 @___read_future_bool(i64 %___lazy_measure)
-  tail call void @___dec_future_refcount(i64 %___lazy_measure)
+  %read_bool = tail call i1 @___read_future_bool(i64 %___future_measure)
+  tail call void @___dec_future_refcount(i64 %___future_measure)
   tail call void @print_bool(ptr nonnull @res_c0.7C14CD6E.0, i64 12, i1 %read_bool)
-  %___lazy_measure9 = tail call i64 @___lazy_measure(i64 %qalloc.i34, i64 0)
+  %___future_measure9 = tail call i64 @___future_measure(i64 %qalloc.i34, i64 0)
   tail call void @___qfree(i64 %qalloc.i34)
-  %read_bool11 = tail call i1 @___read_future_bool(i64 %___lazy_measure9)
-  tail call void @___dec_future_refcount(i64 %___lazy_measure9)
+  %read_bool11 = tail call i1 @___read_future_bool(i64 %___future_measure9)
+  tail call void @___dec_future_refcount(i64 %___future_measure9)
   tail call void @print_bool(ptr nonnull @res_c1.1F7A6571.0, i64 12, i1 %read_bool11)
-  %___lazy_measure17 = tail call i64 @___lazy_measure(i64 %qalloc.i38, i64 0)
+  %___future_measure17 = tail call i64 @___future_measure(i64 %qalloc.i38, i64 0)
   tail call void @___qfree(i64 %qalloc.i38)
-  %read_bool19 = tail call i1 @___read_future_bool(i64 %___lazy_measure17)
-  tail call void @___dec_future_refcount(i64 %___lazy_measure17)
+  %read_bool19 = tail call i1 @___read_future_bool(i64 %___future_measure17)
+  tail call void @___dec_future_refcount(i64 %___future_measure17)
   tail call void @print_bool(ptr nonnull @res_c2.60825383.0, i64 12, i1 %read_bool19)
-  %___lazy_measure25 = tail call i64 @___lazy_measure(i64 %qalloc.i42, i64 0)
+  %___future_measure25 = tail call i64 @___future_measure(i64 %qalloc.i42, i64 0)
   tail call void @___qfree(i64 %qalloc.i42)
-  %read_bool27 = tail call i1 @___read_future_bool(i64 %___lazy_measure25)
-  tail call void @___dec_future_refcount(i64 %___lazy_measure25)
+  %read_bool27 = tail call i1 @___read_future_bool(i64 %___future_measure25)
+  tail call void @___dec_future_refcount(i64 %___future_measure25)
   tail call void @print_bool(ptr nonnull @res_c3.B223E16D.0, i64 12, i1 %read_bool27)
   ret void
 }
 
-declare i64 @___lazy_measure(i64, i64) local_unnamed_addr
+declare i64 @___future_measure(i64, i64) local_unnamed_addr
 
 declare void @___qfree(i64) local_unnamed_addr
 

--- a/qis-compiler/python/tests/snapshots/test_qsystem_platforms/test_llvm_multiplatform/sol-x86_64-windows-msvc-measure_qb_array/measure_qb_array_x86_64-windows-msvc_sol
+++ b/qis-compiler/python/tests/snapshots/test_qsystem_platforms/test_llvm_multiplatform/sol-x86_64-windows-msvc-measure_qb_array/measure_qb_array_x86_64-windows-msvc_sol
@@ -364,7 +364,7 @@ __barray_check_bounds.exit.i:                     ; preds = %__barray_check_boun
   store i64 %106, ptr %100, align 4
   %107 = getelementptr inbounds i64, ptr %.fca.0.extract62.i179.i, i64 %98
   %108 = load i64, ptr %107, align 4
-  %___lazy_measure.i = tail call i64 @___lazy_measure(i64 %108, i64 0)
+  %___future_measure.i = tail call i64 @___future_measure(i64 %108, i64 0)
   tail call void @___qfree(i64 %108)
   %109 = load i64, ptr %74, align 4
   %110 = lshr i64 %109, %"200_0.sroa.15.0178.i"
@@ -381,7 +381,7 @@ loop_body.i:                                      ; preds = %__barray_check_boun
   %114 = xor i64 %109, %113
   store i64 %114, ptr %74, align 4
   %115 = getelementptr inbounds nuw i64, ptr %73, i64 %"200_0.sroa.15.0178.i"
-  store i64 %___lazy_measure.i, ptr %115, align 4
+  store i64 %___future_measure.i, ptr %115, align 4
   %116 = extractvalue { { ptr, ptr, i64 }, i64 } %.pn159177.i, 0
   %.fca.0.extract62.i.i = extractvalue { ptr, ptr, i64 } %116, 0
   %.fca.1.extract63.i.i = extractvalue { ptr, ptr, i64 } %116, 1
@@ -554,7 +554,7 @@ declare i1 @___read_future_bool(i64) local_unnamed_addr
 
 declare void @___dec_future_refcount(i64) local_unnamed_addr
 
-declare i64 @___lazy_measure(i64, i64) local_unnamed_addr
+declare i64 @___future_measure(i64, i64) local_unnamed_addr
 
 declare void @___qfree(i64) local_unnamed_addr
 

--- a/qis-compiler/python/tests/snapshots/test_qsystem_platforms/test_llvm_multiplatform/sol-x86_64-windows-msvc-no_results/no_results_x86_64-windows-msvc_sol
+++ b/qis-compiler/python/tests/snapshots/test_qsystem_platforms/test_llvm_multiplatform/sol-x86_64-windows-msvc-no_results/no_results_x86_64-windows-msvc_sol
@@ -19,14 +19,14 @@ __hugr__.__tk2_sol_qalloc.15.exit:                ; preds = %alloca_block
   tail call void @___reset(i64 %qalloc.i)
   tail call void @___rp(i64 %qalloc.i, double 0x3FF921FB54442D18, double 0xBFF921FB54442D18)
   tail call void @___rz(i64 %qalloc.i, double 0x400921FB54442D18)
-  %___lazy_measure = tail call i64 @___lazy_measure(i64 %qalloc.i, i64 0)
+  %___future_measure = tail call i64 @___future_measure(i64 %qalloc.i, i64 0)
   tail call void @___qfree(i64 %qalloc.i)
-  %read_bool = tail call i1 @___read_future_bool(i64 %___lazy_measure)
-  tail call void @___dec_future_refcount(i64 %___lazy_measure)
+  %read_bool = tail call i1 @___read_future_bool(i64 %___future_measure)
+  tail call void @___dec_future_refcount(i64 %___future_measure)
   ret void
 }
 
-declare i64 @___lazy_measure(i64, i64) local_unnamed_addr
+declare i64 @___future_measure(i64, i64) local_unnamed_addr
 
 declare void @___qfree(i64) local_unnamed_addr
 

--- a/qis-compiler/python/tests/snapshots/test_qsystem_platforms/test_llvm_multiplatform/sol-x86_64-windows-msvc-postselect_exit/postselect_exit_x86_64-windows-msvc_sol
+++ b/qis-compiler/python/tests/snapshots/test_qsystem_platforms/test_llvm_multiplatform/sol-x86_64-windows-msvc-postselect_exit/postselect_exit_x86_64-windows-msvc_sol
@@ -21,10 +21,10 @@ __hugr__.__tk2_sol_qalloc.40.exit:                ; preds = %alloca_block
   tail call void @___reset(i64 %qalloc.i)
   tail call void @___rp(i64 %qalloc.i, double 0x3FF921FB54442D18, double 0xBFF921FB54442D18)
   tail call void @___rz(i64 %qalloc.i, double 0x400921FB54442D18)
-  %___lazy_measure = tail call i64 @___lazy_measure(i64 %qalloc.i, i64 0)
+  %___future_measure = tail call i64 @___future_measure(i64 %qalloc.i, i64 0)
   tail call void @___qfree(i64 %qalloc.i)
-  %read_bool = tail call i1 @___read_future_bool(i64 %___lazy_measure)
-  tail call void @___dec_future_refcount(i64 %___lazy_measure)
+  %read_bool = tail call i1 @___read_future_bool(i64 %___future_measure)
+  tail call void @___dec_future_refcount(i64 %___future_measure)
   br i1 %read_bool, label %1, label %0
 
 0:                                                ; preds = %__hugr__.__tk2_sol_qalloc.40.exit
@@ -36,7 +36,7 @@ __hugr__.__tk2_sol_qalloc.40.exit:                ; preds = %alloca_block
   unreachable
 }
 
-declare i64 @___lazy_measure(i64, i64) local_unnamed_addr
+declare i64 @___future_measure(i64, i64) local_unnamed_addr
 
 declare void @___qfree(i64) local_unnamed_addr
 

--- a/qis-compiler/python/tests/snapshots/test_qsystem_platforms/test_llvm_multiplatform/sol-x86_64-windows-msvc-postselect_panic/postselect_panic_x86_64-windows-msvc_sol
+++ b/qis-compiler/python/tests/snapshots/test_qsystem_platforms/test_llvm_multiplatform/sol-x86_64-windows-msvc-postselect_panic/postselect_panic_x86_64-windows-msvc_sol
@@ -21,10 +21,10 @@ __hugr__.__tk2_sol_qalloc.38.exit:                ; preds = %alloca_block
   tail call void @___reset(i64 %qalloc.i)
   tail call void @___rp(i64 %qalloc.i, double 0x3FF921FB54442D18, double 0xBFF921FB54442D18)
   tail call void @___rz(i64 %qalloc.i, double 0x400921FB54442D18)
-  %___lazy_measure = tail call i64 @___lazy_measure(i64 %qalloc.i, i64 0)
+  %___future_measure = tail call i64 @___future_measure(i64 %qalloc.i, i64 0)
   tail call void @___qfree(i64 %qalloc.i)
-  %read_bool = tail call i1 @___read_future_bool(i64 %___lazy_measure)
-  tail call void @___dec_future_refcount(i64 %___lazy_measure)
+  %read_bool = tail call i1 @___read_future_bool(i64 %___future_measure)
+  tail call void @___dec_future_refcount(i64 %___future_measure)
   br i1 %read_bool, label %1, label %0
 
 0:                                                ; preds = %__hugr__.__tk2_sol_qalloc.38.exit
@@ -36,7 +36,7 @@ __hugr__.__tk2_sol_qalloc.38.exit:                ; preds = %alloca_block
   unreachable
 }
 
-declare i64 @___lazy_measure(i64, i64) local_unnamed_addr
+declare i64 @___future_measure(i64, i64) local_unnamed_addr
 
 declare void @___qfree(i64) local_unnamed_addr
 

--- a/qis-compiler/python/tests/snapshots/test_qsystem_platforms/test_llvm_multiplatform/sol-x86_64-windows-msvc-qft_32/qft_32_x86_64-windows-msvc_sol
+++ b/qis-compiler/python/tests/snapshots/test_qsystem_platforms/test_llvm_multiplatform/sol-x86_64-windows-msvc-qft_32/qft_32_x86_64-windows-msvc_sol
@@ -170,7 +170,7 @@ __barray_check_bounds.exit.i:                     ; preds = %__barray_check_boun
   store i64 %55, ptr %49, align 4
   %56 = getelementptr inbounds i64, ptr %.fca.0.extract62.i179.i, i64 %47
   %57 = load i64, ptr %56, align 4
-  %___lazy_measure.i = tail call i64 @___lazy_measure(i64 %57, i64 0)
+  %___future_measure.i = tail call i64 @___future_measure(i64 %57, i64 0)
   tail call void @___qfree(i64 %57)
   %58 = load i64, ptr %23, align 4
   %59 = lshr i64 %58, %"341_0.sroa.15.0178.i"
@@ -187,7 +187,7 @@ loop_body.i:                                      ; preds = %__barray_check_boun
   %63 = xor i64 %58, %62
   store i64 %63, ptr %23, align 4
   %64 = getelementptr inbounds nuw i64, ptr %22, i64 %"341_0.sroa.15.0178.i"
-  store i64 %___lazy_measure.i, ptr %64, align 4
+  store i64 %___future_measure.i, ptr %64, align 4
   %65 = extractvalue { { ptr, ptr, i64 }, i64 } %.pn159177.i, 0
   %.fca.0.extract62.i.i = extractvalue { ptr, ptr, i64 } %65, 0
   %.fca.1.extract63.i.i = extractvalue { ptr, ptr, i64 } %65, 1
@@ -493,7 +493,7 @@ declare i1 @___read_future_bool(i64) local_unnamed_addr
 
 declare void @___dec_future_refcount(i64) local_unnamed_addr
 
-declare i64 @___lazy_measure(i64, i64) local_unnamed_addr
+declare i64 @___future_measure(i64, i64) local_unnamed_addr
 
 declare void @___qfree(i64) local_unnamed_addr
 

--- a/qis-compiler/python/tests/snapshots/test_qsystem_platforms/test_llvm_multiplatform/sol-x86_64-windows-msvc-rus/rus_x86_64-windows-msvc_sol
+++ b/qis-compiler/python/tests/snapshots/test_qsystem_platforms/test_llvm_multiplatform/sol-x86_64-windows-msvc-rus/rus_x86_64-windows-msvc_sol
@@ -50,10 +50,10 @@ __hugr__.__tk2_sol_qalloc.94.exit94.i:            ; preds = %__hugr__.__tk2_sol_
   tail call void @___rp(i64 %qalloc.i91.i, double 0xBFF921FB54442D18, double 0x3FF921FB54442D18)
   tail call void @___rz(i64 %qalloc.i91.i, double 0xBFF921FB54442D18)
   tail call void @___rz(i64 %qalloc.i100.i, double 0x3FE921FB54442D18)
-  %___lazy_measure.i = tail call i64 @___lazy_measure(i64 %qalloc.i100.i, i64 0)
+  %___future_measure.i = tail call i64 @___future_measure(i64 %qalloc.i100.i, i64 0)
   tail call void @___qfree(i64 %qalloc.i100.i)
-  %read_bool.i.i = tail call i1 @___read_future_bool(i64 %___lazy_measure.i)
-  tail call void @___dec_future_refcount(i64 %___lazy_measure.i)
+  %read_bool.i.i = tail call i1 @___read_future_bool(i64 %___future_measure.i)
+  tail call void @___dec_future_refcount(i64 %___future_measure.i)
   br i1 %read_bool.i.i, label %1, label %0
 
 0:                                                ; preds = %__hugr__.__tk2_sol_qalloc.94.exit94.i
@@ -74,10 +74,10 @@ __hugr__.__tk2_sol_qalloc.94.exit94.i:            ; preds = %__hugr__.__tk2_sol_
   tail call void @___rp(i64 %qalloc.i, double 0xBFF921FB54442D18, double 0x3FF921FB54442D18)
   tail call void @___rz(i64 %qalloc.i, double 0xBFF921FB54442D18)
   tail call void @___rz(i64 %qalloc.i91.i, double 0x3FE921FB54442D18)
-  %___lazy_measure52.i = tail call i64 @___lazy_measure(i64 %qalloc.i91.i, i64 0)
+  %___future_measure52.i = tail call i64 @___future_measure(i64 %qalloc.i91.i, i64 0)
   tail call void @___qfree(i64 %qalloc.i91.i)
-  %read_bool.i97.i = tail call i1 @___read_future_bool(i64 %___lazy_measure52.i)
-  tail call void @___dec_future_refcount(i64 %___lazy_measure52.i)
+  %read_bool.i97.i = tail call i1 @___read_future_bool(i64 %___future_measure52.i)
+  tail call void @___dec_future_refcount(i64 %___future_measure52.i)
   br i1 %read_bool.i97.i, label %"__hugr__.__main__.rus.<locals>.rus.17.exit", label %2
 
 2:                                                ; preds = %1
@@ -85,15 +85,15 @@ __hugr__.__tk2_sol_qalloc.94.exit94.i:            ; preds = %__hugr__.__tk2_sol_
   br label %.backedge.i
 
 "__hugr__.__main__.rus.<locals>.rus.17.exit":     ; preds = %1
-  %___lazy_measure = tail call i64 @___lazy_measure(i64 %qalloc.i, i64 0)
+  %___future_measure = tail call i64 @___future_measure(i64 %qalloc.i, i64 0)
   tail call void @___qfree(i64 %qalloc.i)
-  %read_bool = tail call i1 @___read_future_bool(i64 %___lazy_measure)
-  tail call void @___dec_future_refcount(i64 %___lazy_measure)
+  %read_bool = tail call i1 @___read_future_bool(i64 %___future_measure)
+  tail call void @___dec_future_refcount(i64 %___future_measure)
   tail call void @print_bool(ptr nonnull @res_result.457DE32D.0, i64 16, i1 %read_bool)
   ret void
 }
 
-declare i64 @___lazy_measure(i64, i64) local_unnamed_addr
+declare i64 @___future_measure(i64, i64) local_unnamed_addr
 
 declare void @___qfree(i64) local_unnamed_addr
 

--- a/qis-compiler/python/tests/snapshots/test_qsystem_platforms/test_llvm_multiplatform/sol-x86_64-windows-msvc-simple_modifier/simple_modifier_x86_64-windows-msvc_sol
+++ b/qis-compiler/python/tests/snapshots/test_qsystem_platforms/test_llvm_multiplatform/sol-x86_64-windows-msvc-simple_modifier/simple_modifier_x86_64-windows-msvc_sol
@@ -60,15 +60,15 @@ __hugr__.__tk2_sol_qalloc.39.exit38:              ; preds = %__barray_check_none
   %7 = tail call ptr @heap_alloc(i64 8)
   store i64 0, ptr %7, align 1
   %8 = load i64, ptr %6, align 4
-  %___lazy_measure = tail call i64 @___lazy_measure(i64 %8, i64 0)
+  %___future_measure = tail call i64 @___future_measure(i64 %8, i64 0)
   tail call void @___qfree(i64 %8)
-  %read_bool = tail call i1 @___read_future_bool(i64 %___lazy_measure)
-  tail call void @___dec_future_refcount(i64 %___lazy_measure)
+  %read_bool = tail call i1 @___read_future_bool(i64 %___future_measure)
+  tail call void @___dec_future_refcount(i64 %___future_measure)
   tail call void @print_bool(ptr nonnull @res_c0.7C14CD6E.0, i64 12, i1 %read_bool)
-  %___lazy_measure19 = tail call i64 @___lazy_measure(i64 %qalloc.i35, i64 0)
+  %___future_measure19 = tail call i64 @___future_measure(i64 %qalloc.i35, i64 0)
   tail call void @___qfree(i64 %qalloc.i35)
-  %read_bool21 = tail call i1 @___read_future_bool(i64 %___lazy_measure19)
-  tail call void @___dec_future_refcount(i64 %___lazy_measure19)
+  %read_bool21 = tail call i1 @___read_future_bool(i64 %___future_measure19)
+  tail call void @___dec_future_refcount(i64 %___future_measure19)
   tail call void @print_bool(ptr nonnull @res_c1.1F7A6571.0, i64 12, i1 %read_bool21)
   ret void
 }
@@ -78,7 +78,7 @@ declare ptr @heap_alloc(i64) local_unnamed_addr
 ; Function Attrs: noreturn
 declare void @panic(i32, ptr) local_unnamed_addr #0
 
-declare i64 @___lazy_measure(i64, i64) local_unnamed_addr
+declare i64 @___future_measure(i64, i64) local_unnamed_addr
 
 declare void @___qfree(i64) local_unnamed_addr
 

--- a/tket-qsystem/src/llvm/qsystem.rs
+++ b/tket-qsystem/src/llvm/qsystem.rs
@@ -178,7 +178,7 @@ enum SolRuntimeFunction {
     Rp,
     Rpp,
     // Sol uses the same function for all measurement types
-    LazyMeasure,
+    FutureMeasure,
 }
 
 impl QSystemRuntimeFunction for SolRuntimeFunction {
@@ -186,7 +186,7 @@ impl QSystemRuntimeFunction for SolRuntimeFunction {
         match self {
             SolRuntimeFunction::Rp => "___rp",
             SolRuntimeFunction::Rpp => "___rpp",
-            SolRuntimeFunction::LazyMeasure => "___lazy_measure",
+            SolRuntimeFunction::FutureMeasure => "___future_measure",
         }
     }
 
@@ -206,7 +206,7 @@ impl QSystemRuntimeFunction for SolRuntimeFunction {
             SolRuntimeFunction::Rpp => iwc
                 .void_type()
                 .fn_type(&[qubit, qubit, float, float], false),
-            SolRuntimeFunction::LazyMeasure => {
+            SolRuntimeFunction::FutureMeasure => {
                 future_type(iwc).fn_type(&[qubit, iwc.i64_type().into()], false)
             }
         }
@@ -448,7 +448,7 @@ impl<PCG: PreludeCodegen> QSystemCodegenExtension<PCG> {
                 self.emit_lazy_measure_op(
                     context,
                     args,
-                    RuntimeFunction::Sol(SolRuntimeFunction::LazyMeasure),
+                    RuntimeFunction::Sol(SolRuntimeFunction::FutureMeasure),
                     &[flags],
                     false,
                 )
@@ -459,7 +459,7 @@ impl<PCG: PreludeCodegen> QSystemCodegenExtension<PCG> {
                 self.emit_lazy_measure_op(
                     context,
                     args,
-                    RuntimeFunction::Sol(SolRuntimeFunction::LazyMeasure),
+                    RuntimeFunction::Sol(SolRuntimeFunction::FutureMeasure),
                     &[flags],
                     false,
                 )
@@ -469,7 +469,7 @@ impl<PCG: PreludeCodegen> QSystemCodegenExtension<PCG> {
                 self.emit_lazy_measure_op(
                     context,
                     args,
-                    RuntimeFunction::Sol(SolRuntimeFunction::LazyMeasure),
+                    RuntimeFunction::Sol(SolRuntimeFunction::FutureMeasure),
                     &[flags],
                     true,
                 )

--- a/tket-qsystem/src/llvm/snapshots/tket_qsystem__llvm__qsystem__test__emit_sol_codegen@llvm21_10.snap
+++ b/tket-qsystem/src/llvm/snapshots/tket_qsystem__llvm__qsystem__test__emit_sol_codegen@llvm21_10.snap
@@ -10,12 +10,12 @@ alloca_block:
   br label %entry_block
 
 entry_block:                                      ; preds = %alloca_block
-  %___lazy_measure = call i64 @___lazy_measure(i64 %0, i64 1), !dbg !8
+  %___future_measure = call i64 @___future_measure(i64 %0, i64 1), !dbg !8
   call void @___qfree(i64 %0), !dbg !8
-  ret i64 %___lazy_measure
+  ret i64 %___future_measure
 }
 
-declare i64 @___lazy_measure(i64, i64)
+declare i64 @___future_measure(i64, i64)
 
 declare void @___qfree(i64)
 

--- a/tket-qsystem/src/llvm/snapshots/tket_qsystem__llvm__qsystem__test__emit_sol_codegen@llvm21_11.snap
+++ b/tket-qsystem/src/llvm/snapshots/tket_qsystem__llvm__qsystem__test__emit_sol_codegen@llvm21_11.snap
@@ -10,14 +10,14 @@ alloca_block:
   br label %entry_block
 
 entry_block:                                      ; preds = %alloca_block
-  %___lazy_measure = call i64 @___lazy_measure(i64 %0, i64 0), !dbg !10
+  %___future_measure = call i64 @___future_measure(i64 %0, i64 0), !dbg !10
   call void @___reset(i64 %0), !dbg !10
   %mrv = insertvalue { i64, i64 } poison, i64 %0, 0
-  %mrv6 = insertvalue { i64, i64 } %mrv, i64 %___lazy_measure, 1
+  %mrv6 = insertvalue { i64, i64 } %mrv, i64 %___future_measure, 1
   ret { i64, i64 } %mrv6
 }
 
-declare i64 @___lazy_measure(i64, i64)
+declare i64 @___future_measure(i64, i64)
 
 declare void @___reset(i64)
 

--- a/tket-qsystem/src/llvm/snapshots/tket_qsystem__llvm__qsystem__test__emit_sol_codegen@llvm21_5.snap
+++ b/tket-qsystem/src/llvm/snapshots/tket_qsystem__llvm__qsystem__test__emit_sol_codegen@llvm21_5.snap
@@ -10,12 +10,12 @@ alloca_block:
   br label %entry_block
 
 entry_block:                                      ; preds = %alloca_block
-  %___lazy_measure = call i64 @___lazy_measure(i64 %0, i64 0), !dbg !8
+  %___future_measure = call i64 @___future_measure(i64 %0, i64 0), !dbg !8
   call void @___qfree(i64 %0), !dbg !8
-  ret i64 %___lazy_measure
+  ret i64 %___future_measure
 }
 
-declare i64 @___lazy_measure(i64, i64)
+declare i64 @___future_measure(i64, i64)
 
 declare void @___qfree(i64)
 

--- a/tket-qsystem/src/llvm/snapshots/tket_qsystem__llvm__qsystem__test__emit_sol_codegen@pre-mem2reg@llvm21_10.snap
+++ b/tket-qsystem/src/llvm/snapshots/tket_qsystem__llvm__qsystem__test__emit_sol_codegen@pre-mem2reg@llvm21_10.snap
@@ -15,16 +15,16 @@ alloca_block:
 entry_block:                                      ; preds = %alloca_block
   store i64 %0, ptr %"2_0", align 4
   %"2_01" = load i64, ptr %"2_0", align 4
-  %___lazy_measure = call i64 @___lazy_measure(i64 %"2_01", i64 1), !dbg !8
+  %___future_measure = call i64 @___future_measure(i64 %"2_01", i64 1), !dbg !8
   call void @___qfree(i64 %"2_01"), !dbg !8
-  store i64 %___lazy_measure, ptr %"4_0", align 4, !dbg !8
+  store i64 %___future_measure, ptr %"4_0", align 4, !dbg !8
   %"4_02" = load i64, ptr %"4_0", align 4
   store i64 %"4_02", ptr %"0", align 4
   %"03" = load i64, ptr %"0", align 4
   ret i64 %"03"
 }
 
-declare i64 @___lazy_measure(i64, i64)
+declare i64 @___future_measure(i64, i64)
 
 declare void @___qfree(i64)
 

--- a/tket-qsystem/src/llvm/snapshots/tket_qsystem__llvm__qsystem__test__emit_sol_codegen@pre-mem2reg@llvm21_11.snap
+++ b/tket-qsystem/src/llvm/snapshots/tket_qsystem__llvm__qsystem__test__emit_sol_codegen@pre-mem2reg@llvm21_11.snap
@@ -17,10 +17,10 @@ alloca_block:
 entry_block:                                      ; preds = %alloca_block
   store i64 %0, ptr %"2_0", align 4
   %"2_01" = load i64, ptr %"2_0", align 4
-  %___lazy_measure = call i64 @___lazy_measure(i64 %"2_01", i64 0), !dbg !10
+  %___future_measure = call i64 @___future_measure(i64 %"2_01", i64 0), !dbg !10
   call void @___reset(i64 %"2_01"), !dbg !10
   store i64 %"2_01", ptr %"4_0", align 4, !dbg !10
-  store i64 %___lazy_measure, ptr %"4_1", align 4, !dbg !10
+  store i64 %___future_measure, ptr %"4_1", align 4, !dbg !10
   %"4_02" = load i64, ptr %"4_0", align 4
   %"4_13" = load i64, ptr %"4_1", align 4
   store i64 %"4_02", ptr %"0", align 4
@@ -32,7 +32,7 @@ entry_block:                                      ; preds = %alloca_block
   ret { i64, i64 } %mrv6
 }
 
-declare i64 @___lazy_measure(i64, i64)
+declare i64 @___future_measure(i64, i64)
 
 declare void @___reset(i64)
 

--- a/tket-qsystem/src/llvm/snapshots/tket_qsystem__llvm__qsystem__test__emit_sol_codegen@pre-mem2reg@llvm21_5.snap
+++ b/tket-qsystem/src/llvm/snapshots/tket_qsystem__llvm__qsystem__test__emit_sol_codegen@pre-mem2reg@llvm21_5.snap
@@ -15,16 +15,16 @@ alloca_block:
 entry_block:                                      ; preds = %alloca_block
   store i64 %0, ptr %"2_0", align 4
   %"2_01" = load i64, ptr %"2_0", align 4
-  %___lazy_measure = call i64 @___lazy_measure(i64 %"2_01", i64 0), !dbg !8
+  %___future_measure = call i64 @___future_measure(i64 %"2_01", i64 0), !dbg !8
   call void @___qfree(i64 %"2_01"), !dbg !8
-  store i64 %___lazy_measure, ptr %"4_0", align 4, !dbg !8
+  store i64 %___future_measure, ptr %"4_0", align 4, !dbg !8
   %"4_02" = load i64, ptr %"4_0", align 4
   store i64 %"4_02", ptr %"0", align 4
   %"03" = load i64, ptr %"0", align 4
   ret i64 %"03"
 }
 
-declare i64 @___lazy_measure(i64, i64)
+declare i64 @___future_measure(i64, i64)
 
 declare void @___qfree(i64)
 


### PR DESCRIPTION
Renamed to avoid collision with the Helios namespace.

Closes #1937 

BREAKING CHANGE: Renamed sol `___lazy_measure ` symbol to `___future_measure`