### PR TITLE
feat: Add re-exports for ComposablePass definitions

### DIFF
--- a/tket-py/tket/passes/composable.py
+++ b/tket-py/tket/passes/composable.py
@@ -1,0 +1,17 @@
+"""A Protocol for a composable pass."""
+
+from hugr.passes.composable import (
+    ComposablePass,
+    ComposedPass,
+    PassName,
+    PassResult,
+    implement_pass_run,
+)
+
+__all__ = [
+    "ComposablePass",
+    "ComposedPass",
+    "PassName",
+    "PassResult",
+    "implement_pass_run",
+]

--- a/tket-py/tket/passes/scope.py
+++ b/tket-py/tket/passes/scope.py
@@ -1,0 +1,29 @@
+"""Scope configuration for a pass.
+
+A `PassScope` defines the parts of a HUGR that a pass should be applied to, and
+which parts is it allowed to modify. Each variant defines three properties: `root`,
+`preserve_interface` and `recursive`.
+
+From these, `regions` and `in_scope` can be derived.
+
+A pass will always optimize the entrypoint region, unless the entrypoint is the
+module root.
+"""
+
+from hugr.passes.scope import (
+    ABCEnumMeta,
+    GlobalScope,
+    InScope,
+    LocalScope,
+    PassScope,
+    PassScopeBase,
+)
+
+__all__ = [
+    "ABCEnumMeta",
+    "GlobalScope",
+    "InScope",
+    "LocalScope",
+    "PassScope",
+    "PassScopeBase",
+]


### PR DESCRIPTION
Adds re-exports for `ComposablePass` and `PassScope` definitions, to help with migrating before we remove them from `hugr`. See https://github.com/Quantinuum/tket2/issues/1705.