### PR TITLE
perf: Use patched hugr with cached types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1098,8 +1098,7 @@ dependencies = [
 [[package]]
 name = "hugr"
 version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80349c75261e201a6f0592e3ee5ba98379512826bc18642ee20c6be692c4da80"
+source = "git+https://github.com/quantinuum/hugr?rev=63972fb15aa553cc0db6761abb50a24b7f34f83e#63972fb15aa553cc0db6761abb50a24b7f34f83e"
 dependencies = [
  "hugr-core",
  "hugr-llvm",
@@ -1109,8 +1108,7 @@ dependencies = [
 [[package]]
 name = "hugr-cli"
 version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6c180ab65267e65175bebe2546507fab8521f3665681a5c08484fc0e3bff357"
+source = "git+https://github.com/quantinuum/hugr?rev=63972fb15aa553cc0db6761abb50a24b7f34f83e#63972fb15aa553cc0db6761abb50a24b7f34f83e"
 dependencies = [
  "anyhow",
  "clap",
@@ -1131,8 +1129,7 @@ dependencies = [
 [[package]]
 name = "hugr-core"
 version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78147193f6a933130adcf5ca4e119228524d0a5393f27e2b0d6c0920de42024d"
+source = "git+https://github.com/quantinuum/hugr?rev=63972fb15aa553cc0db6761abb50a24b7f34f83e#63972fb15aa553cc0db6761abb50a24b7f34f83e"
 dependencies = [
  "base64 0.23.1",
  "cgmath",
@@ -1169,8 +1166,7 @@ dependencies = [
 [[package]]
 name = "hugr-llvm"
 version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "499baf84844496b536013e15f4e3cb59163cea4eb571136b8ae29ca5b0582638"
+source = "git+https://github.com/quantinuum/hugr?rev=63972fb15aa553cc0db6761abb50a24b7f34f83e#63972fb15aa553cc0db6761abb50a24b7f34f83e"
 dependencies = [
  "anyhow",
  "cc",
@@ -1190,8 +1186,7 @@ dependencies = [
 [[package]]
 name = "hugr-model"
 version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3fd86a36f80a200849cd5df1c02b54a947eaeb1e0663fab567e1a00aa450dfa"
+source = "git+https://github.com/quantinuum/hugr?rev=63972fb15aa553cc0db6761abb50a24b7f34f83e#63972fb15aa553cc0db6761abb50a24b7f34f83e"
 dependencies = [
  "base64 0.23.1",
  "bumpalo",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,10 +41,10 @@ large_enum_variant = "allow"
 [patch.crates-io]
 
 # Uncomment to use unreleased versions of hugr
-#hugr = { git = "https://github.com/quantinuum/hugr", "rev" = "1787e12" }
-#hugr-core = { git = "https://github.com/quantinuum/hugr", "rev" = "1787e12" }
-#hugr-cli = { git = "https://github.com/quantinuum/hugr", "rev" = "1787e12" }
-#hugr-llvm = { git = "https://github.com/quantinuum/hugr", "rev" = "1787e12" }
+hugr = { git = "https://github.com/quantinuum/hugr", "rev" = "63972fb15aa553cc0db6761abb50a24b7f34f83e" }
+hugr-core = { git = "https://github.com/quantinuum/hugr", "rev" = "63972fb15aa553cc0db6761abb50a24b7f34f83e" }
+hugr-cli = { git = "https://github.com/quantinuum/hugr", "rev" = "63972fb15aa553cc0db6761abb50a24b7f34f83e" }
+hugr-llvm = { git = "https://github.com/quantinuum/hugr", "rev" = "63972fb15aa553cc0db6761abb50a24b7f34f83e" }
 # portgraph = { git = "https://github.com/quantinuum/portgraph", rev = "68b96ac737e0c285d8c543b2d74a7aa80a18202c" }
 
 [workspace.dependencies]

--- a/tket/src/extension/measurement.rs
+++ b/tket/src/extension/measurement.rs
@@ -1,4 +1,4 @@
-use std::sync::{Arc, Weak};
+use std::sync::{Arc, LazyLock, Weak};
 
 use hugr::{
     Extension, Wire,
@@ -57,9 +57,12 @@ pub fn measurement_custom_type() -> CustomType {
         .unwrap()
 }
 
+/// Shared storage for the concrete measurement type.
+static MEASUREMENT_TYPE: LazyLock<Type> = LazyLock::new(|| measurement_custom_type().into());
+
 /// Returns a `Measurement` [Type].
 pub fn measurement_type() -> Type {
-    measurement_custom_type().into()
+    MEASUREMENT_TYPE.clone()
 }
 
 #[derive(

--- a/tket/src/extension/rotation.rs
+++ b/tket/src/extension/rotation.rs
@@ -15,7 +15,7 @@ use hugr::{
 };
 use smol_str::SmolStr;
 use std::f64::consts::PI;
-use std::sync::{Arc, Weak};
+use std::sync::{Arc, LazyLock, Weak};
 use strum::{EnumIter, EnumString, IntoStaticStr};
 
 use lazy_static::lazy_static;
@@ -49,9 +49,13 @@ pub fn rotation_custom_type(extension_ref: &Weak<Extension>) -> CustomType {
     )
 }
 
+/// Shared storage for the commonly used concrete rotation type.
+static ROTATION_TYPE: LazyLock<Type> =
+    LazyLock::new(|| rotation_custom_type(&Arc::downgrade(&ROTATION_EXTENSION)).into());
+
 /// Type representing a rotation that is a number of half turns (as [Type])
 pub fn rotation_type() -> Type {
-    rotation_custom_type(&Arc::downgrade(&ROTATION_EXTENSION)).into()
+    ROTATION_TYPE.clone()
 }
 
 /// A rotation


### PR DESCRIPTION
Update hugr to https://github.com/Quantinuum/hugr/pull/3241 to check the CI benchmark times here