### PR TITLE
feat!: Remove deprecated definitions from tket-py

### DIFF
--- a/qis-compiler/README.md
+++ b/qis-compiler/README.md
@@ -21,7 +21,7 @@ This can then be compiled to LLVM IR or bitcode
 using this package:
 
 ```python
-from qis_compiler import (
+from selene_hugr_qis_compiler import (
     compile_to_llvm_ir,
     compile_to_bitcode,
 )

--- a/tket-py/test/test_pass.py
+++ b/tket-py/test/test_pass.py
@@ -22,13 +22,12 @@ from tket.passes import (
     InlineFunctions,
     ModifierResolverPass,
     Normalize,
-    NormalizeGuppy,
     PlatformTarget,
     PytketHugrPass,
+    QSystemLLVMPass,
     QSystemRebasePass,
     _badger_optimise,
     _greedy_depth_reduce,
-    _QSystemLLVMPass,
     inline_funcs,
 )
 
@@ -293,13 +292,6 @@ def test_normalize_guppy():
     assert normal_circ1.circuit_cost(lambda op: int(op == TketOp.CX)) == 3
 
 
-def test_normalize_guppy_deprecated_alias():
-    with pytest.deprecated_call(match="Use `Normalize` instead"):
-        normalize = NormalizeGuppy()
-
-    assert isinstance(normalize, Normalize)
-
-
 def test_modifier_resolver() -> None:
     normalize = Normalize(resolve_modifiers=False)
     normalize_with_modifier_resolution = Normalize()
@@ -482,7 +474,7 @@ def test_python_qsystem_pass() -> None:
     normalize = Normalize()
     hugr = normalize(_hugr_from_path("test_files/guppy_examples/flat_quantum.hugr"))
     qsystem_rebase = QSystemRebasePass()
-    qsystem_llvm = _QSystemLLVMPass()
+    qsystem_llvm = QSystemLLVMPass()
     qsystem_hugr = qsystem_llvm(qsystem_rebase(hugr))
     assert _count_ops(qsystem_hugr, "ZZPhase") == 1
     assert _count_ops(qsystem_hugr, "Custom") == 0
@@ -495,7 +487,7 @@ def test_python_qsystem_pass_with_modifiers() -> None:
     This won't actually do anything useful, we just want to check that the pass
     runs without errors."""
     qsystem_rebase = QSystemRebasePass()
-    qsystem_llvm = _QSystemLLVMPass()
+    qsystem_llvm = QSystemLLVMPass()
     failures = []
     for hugr_path in sorted(Path("test_files/modifier_examples").glob("*.hugr")):
         try:

--- a/tket-py/test/test_pass.py
+++ b/tket-py/test/test_pass.py
@@ -24,10 +24,10 @@ from tket.passes import (
     Normalize,
     PlatformTarget,
     PytketHugrPass,
-    QSystemLLVMPass,
     QSystemRebasePass,
     _badger_optimise,
     _greedy_depth_reduce,
+    _QSystemLLVMPass,
     inline_funcs,
 )
 
@@ -474,7 +474,7 @@ def test_python_qsystem_pass() -> None:
     normalize = Normalize()
     hugr = normalize(_hugr_from_path("test_files/guppy_examples/flat_quantum.hugr"))
     qsystem_rebase = QSystemRebasePass()
-    qsystem_llvm = QSystemLLVMPass()
+    qsystem_llvm = _QSystemLLVMPass()
     qsystem_hugr = qsystem_llvm(qsystem_rebase(hugr))
     assert _count_ops(qsystem_hugr, "ZZPhase") == 1
     assert _count_ops(qsystem_hugr, "Custom") == 0
@@ -487,7 +487,7 @@ def test_python_qsystem_pass_with_modifiers() -> None:
     This won't actually do anything useful, we just want to check that the pass
     runs without errors."""
     qsystem_rebase = QSystemRebasePass()
-    qsystem_llvm = QSystemLLVMPass()
+    qsystem_llvm = _QSystemLLVMPass()
     failures = []
     for hugr_path in sorted(Path("test_files/modifier_examples").glob("*.hugr")):
         try:

--- a/tket-py/tket/metadata.py
+++ b/tket-py/tket/metadata.py
@@ -11,10 +11,10 @@ Examples:
     >>> hugr = Hugr()
     >>> node = hugr[hugr.module_root]
     >>>
-    >>> node.metadata[MaxQubitsHint] = 3
+    >>> node.metadata[ExpectedQubitsHint] = 3
     >>> node.metadata[PytketInputParameters] = ["theta", "phi"]
     >>> node.metadata[PytketQubitRegisterNames] = [("q", [0]), ("ancilla", [1])]
-    >>> node.metadata[MaxQubitsHint]
+    >>> node.metadata[ExpectedQubitsHint]
     3
     >>> node.metadata.get(PytketQubitRegisterNames)
     [('q', [0]), ('ancilla', [1])]
@@ -28,7 +28,6 @@ from typing import TYPE_CHECKING, Literal, TypeAlias, TypedDict
 from hugr.metadata import Metadata
 from pydantic import StrictBool, TypeAdapter
 from pydantic.dataclasses import dataclass
-from typing_extensions import deprecated
 
 from ._tket import metadata as _metadata
 
@@ -41,6 +40,7 @@ __all__ = [
     "ControlledImplementations",
     "CtrlDaggeredImplementations",
     "DaggeredImplementation",
+    "ExpectedQubitsHint",
     "HeliosPlatformConfig",
     "HeliosPlatformConfigValue",
     "InlineAnnotation",
@@ -50,7 +50,6 @@ __all__ = [
     "PytketBitRegisterNames",
     "PytketInputParameters",
     "PytketOpGroup",
-    "PytketPhaseExpr",
     "PytketQubit",
     "PytketQubitRegisterNames",
     "RewriteTraceValue",
@@ -196,17 +195,6 @@ class PytketQubitRegisterNames(Metadata[list[PytketQubit]]):
     @classmethod
     def from_json(cls, value: JsonType) -> list[PytketQubit]:
         return _read_pytket_register(cls.KEY, value)
-
-
-@deprecated("Call `used_extensions` on the hugr instead.")
-class PytketPhaseExpr(Metadata[str]):
-    """Metadata key for the serialized pytket global phase expression.
-
-    Deprecated:
-        Use explicit ``tket.global_phase`` operations instead.
-    """
-
-    KEY = "TKET1.phase"
 
 
 def _store_pytket_register(value: list[tuple[str, list[int]]]) -> JsonType:

--- a/tket-py/tket/passes/__init__.py
+++ b/tket-py/tket/passes/__init__.py
@@ -15,7 +15,6 @@ from hugr.passes.composable import (
     implement_pass_run,
 )
 from hugr.passes.scope import GlobalScope, PassScope
-from typing_extensions import deprecated
 
 from tket import _state
 
@@ -34,12 +33,11 @@ __all__ = [
     "InlineFunctions",
     "ModifierResolverPass",
     "Normalize",
-    "NormalizeGuppy",
     "PassResult",
     "PlatformTarget",
     "PytketHugrPass",
+    "QSystemLLVMPass",
     "QSystemRebasePass",
-    "_QSystemLLVMPass",
 ]
 
 
@@ -226,11 +224,6 @@ class Normalize(ComposablePass):
             scope=self._scope,
         )
         return program
-
-
-@deprecated("Use `Normalize` instead.")
-class NormalizeGuppy(Normalize):
-    """Deprecated alias for :py:class:`Normalize`."""
 
 
 @cache
@@ -506,7 +499,7 @@ class QSystemRebasePass(ComposablePass):
 
 
 @dataclass(kw_only=True)
-class _QSystemLLVMPass(ComposablePass):
+class QSystemLLVMPass(ComposablePass):
     """Prepare a QSystem program for LLVM lowering.
 
     This is normally called automatically by the tools before LLVM lowering.
@@ -530,7 +523,7 @@ class _QSystemLLVMPass(ComposablePass):
             copy_call=lambda h: self._qsystem_llvm(h, inplace),
         )
 
-    def with_scope(self, scope: PassScope) -> _QSystemLLVMPass:
+    def with_scope(self, scope: PassScope) -> QSystemLLVMPass:
         """Set the scope of this pass and return self."""
         self._scope = scope
         return self

--- a/tket-py/tket/passes/__init__.py
+++ b/tket-py/tket/passes/__init__.py
@@ -36,8 +36,8 @@ __all__ = [
     "PassResult",
     "PlatformTarget",
     "PytketHugrPass",
-    "QSystemLLVMPass",
     "QSystemRebasePass",
+    "_QSystemLLVMPass",
 ]
 
 
@@ -499,7 +499,7 @@ class QSystemRebasePass(ComposablePass):
 
 
 @dataclass(kw_only=True)
-class QSystemLLVMPass(ComposablePass):
+class _QSystemLLVMPass(ComposablePass):
     """Prepare a QSystem program for LLVM lowering.
 
     This is normally called automatically by the tools before LLVM lowering.
@@ -523,7 +523,7 @@ class QSystemLLVMPass(ComposablePass):
             copy_call=lambda h: self._qsystem_llvm(h, inplace),
         )
 
-    def with_scope(self, scope: PassScope) -> QSystemLLVMPass:
+    def with_scope(self, scope: PassScope) -> _QSystemLLVMPass:
         """Set the scope of this pass and return self."""
         self._scope = scope
         return self


### PR DESCRIPTION
drive-by: Fix some incorrect doc examples.
drive-by: Added missing `ExpectedQubitsHint` in `tket.metadata.__all__`.

BREAKING CHANGE: Removed deprecated `tket.passes.NormalizeGuppy`. Use `Normalize` instead.
BREAKING CHANGE: Removed deprecated `tket.metadata.PytketPhaseExpr`.
BREAKING CHANGE: Renamed `tket.passes._QSystemLLVMPass` to `tket.passes.QSystemLLVMPass`.