### PR TITLE
fix: Decode pytket circuits that have reordered parameter-producing barriers

### DIFF
--- a/tket-py/tket/_state/__init__.py
+++ b/tket-py/tket/_state/__init__.py
@@ -133,8 +133,9 @@ class CompilationState:
         # (as json), passing them, and loading them in
         # `_program.CompilationState.from_bytes` before parsing the envelope.
         #
-        # Remember to filter out the embedded extensions from _program.embedded_extensions(),
-        # since we use those already when loading things in Rust.
+        # Remember to filter out the embedded extensions from
+        # _program.embedded_extensions(), since we use those already when
+        # loading things in Rust.
 
         return CompilationState(
             _inner=_state.CompilationState.from_bytes(envelope),

--- a/tket/src/serialize/pytket/circuit.rs
+++ b/tket/src/serialize/pytket/circuit.rs
@@ -277,6 +277,9 @@ impl EncodedCircuit<Node> {
                 Some(&self.opaque_subgraphs),
             )?;
             decoder.reserve_boundary_parameters(&encoded.boundaries);
+            for segment in &encoded.serial_circuits {
+                decoder.reserve_command_parameters(&segment.commands);
+            }
             decoder.connect_straight_through_wires(&encoded.straight_through_wires);
             for (segment, boundary) in encoded.serial_circuits.iter().zip(&encoded.boundaries) {
                 decoder.insert_boundary(boundary)?;

--- a/tket/src/serialize/pytket/decoder.rs
+++ b/tket/src/serialize/pytket/decoder.rs
@@ -41,9 +41,10 @@ use crate::serialize::pytket::circuit::{
 use crate::serialize::pytket::config::PytketDecoderConfig;
 use crate::serialize::pytket::decoder::wires::WireTracker;
 use crate::serialize::pytket::extension::{RegisterCount, build_opaque_tket_op};
-use crate::serialize::pytket::opaque::{EncodedEdgeID, OpaqueSubgraphs};
+use crate::serialize::pytket::opaque::{EncodedEdgeID, OpaqueSubgraphPayload, OpaqueSubgraphs};
 use crate::serialize::pytket::{
-    DecodeInsertionTarget, DecodeOptions, PytketDecodeErrorInner, default_decoder_config,
+    DecodeInsertionTarget, DecodeOptions, PARAMETER_TYPES, PytketDecodeErrorInner,
+    default_decoder_config,
 };
 
 /// State of the tket circuit being decoded.
@@ -587,7 +588,51 @@ impl<'h> PytketDecoderContext<'h> {
         &mut self,
         commands: &[circuit_json::Command],
     ) -> Result<(), PytketDecodeError> {
+        self.reserve_command_parameters(commands);
         self.run_commands(commands)
+    }
+
+    /// Reserve parameters produced by opaque barriers in a command sequence.
+    ///
+    /// Pytket cannot see parameter dependencies carried by barrier payloads,
+    /// so it may move a consuming command before the barrier that produces its
+    /// parameter. Reserving all such outputs before decoding prevents an early
+    /// use from being mistaken for a new region input.
+    pub(super) fn reserve_command_parameters(&mut self, commands: &[circuit_json::Command]) {
+        let Some(subgraphs) = self.opaque_subgraphs else {
+            return;
+        };
+
+        let mut params = IndexSet::new();
+        for command in commands {
+            if command.op.op_type != tket_json_rs::OpType::Barrier {
+                continue;
+            }
+            let Some(payload) = command.op.data.as_deref() else {
+                continue;
+            };
+            let Some((id, _)) = OpaqueSubgraphPayload::parse_external_payload(payload) else {
+                continue;
+            };
+            let Some(subgraph) = subgraphs.get(id) else {
+                continue;
+            };
+
+            for i in 0..subgraph
+                .signature()
+                .output()
+                .iter()
+                .filter(|ty| PARAMETER_TYPES.contains(ty))
+                .count()
+            {
+                params.insert(id.output_parameter(i));
+            }
+        }
+
+        for param in params {
+            self.wire_tracker
+                .reserve_forward_parameter(param, &mut self.builder);
+        }
     }
 
     /// Decode a contiguous list of pytket commands.

--- a/tket/src/serialize/pytket/decoder.rs
+++ b/tket/src/serialize/pytket/decoder.rs
@@ -51,10 +51,9 @@ use crate::serialize::pytket::{
 ///
 /// The state of a DFG being built from a [`SerialCircuit`] into a Hugr.
 ///
-/// The lifetime parameter `'h` is the lifetime of the target Hugr, as well
-/// as the lifetime of the external subgraphs referenced by
-/// [`OpaqueSubgraphPayload`][super::opaque::OpaqueSubgraphPayload]s in the
-/// pytket circuit.
+/// The lifetime parameter `'h` is the lifetime of the target Hugr, as well as
+/// the lifetime of the external subgraphs referenced by
+/// [`OpaqueSubgraphPayload`]s in the pytket circuit.
 #[derive(Debug)]
 pub struct PytketDecoderContext<'h> {
     /// The Hugr being built.

--- a/tket/src/serialize/pytket/tests.rs
+++ b/tket/src/serialize/pytket/tests.rs
@@ -1094,6 +1094,40 @@ fn circ_forward_opaque_parameter() -> Hugr {
     h.finish_hugr_with_outputs([q, rotation]).unwrap()
 }
 
+/// A parameter produced by an opaque barrier and consumed by a supported gate
+/// on a separate qubit.
+#[fixture]
+fn circ_reordered_opaque_parameter() -> Hugr {
+    let signature = Signature::new_endo(vec![qb_t(), qb_t()]);
+    let mut h = FunctionBuilder::new("reordered_opaque_parameter", signature).unwrap();
+    let [q0, q1] = h.input_wires_arr();
+
+    let [q0, parameter] = {
+        let mut producer = h
+            .dfg_builder(
+                Signature::new(vec![qb_t()], vec![qb_t(), float64_type()]),
+                [q0],
+            )
+            .unwrap();
+        let [q0] = producer.input_wires_arr();
+        let parameter = producer.add_load_value(ConstF64::new(0.5));
+        producer
+            .finish_with_outputs([q0, parameter])
+            .unwrap()
+            .outputs_arr()
+    };
+    let [parameter] = h
+        .add_dataflow_op(RotationOp::from_halfturns_unchecked, [parameter])
+        .unwrap()
+        .outputs_arr();
+    let [q1] = h
+        .add_dataflow_op(TketOp::Rz, [q1, parameter])
+        .unwrap()
+        .outputs_arr();
+
+    h.finish_hugr_with_outputs([q0, q1]).unwrap()
+}
+
 /// A register-free opaque subgraph ordered between two supported command runs.
 ///
 /// Regression test for <https://github.com/Quantinuum/tket2/issues/1856>.
@@ -1543,6 +1577,30 @@ fn fail_on_modified_hugr(circ_tk1_ops: Hugr) {
             ..
         })
     );
+}
+
+/// Parameters produced by opaque barriers remain data dependencies even though
+/// pytket only sees independent commands on separate qubit registers.
+#[rstest]
+fn decode_parameter_used_before_opaque_barrier(circ_reordered_opaque_parameter: Hugr) {
+    let mut encoded = EncodedCircuit::new(
+        &circ_reordered_opaque_parameter,
+        EncodeOptions::new().with_subcircuits(true),
+    )
+    .unwrap();
+
+    let (_, circuit) = encoded
+        .iter_mut()
+        .exactly_one()
+        .unwrap_or_else(|_| panic!("fixture should encode as one circuit"));
+    assert_eq!(circuit.commands.len(), 2);
+    assert_eq!(circuit.commands[0].op.op_type, optype::OpType::Barrier);
+    assert_eq!(circuit.commands[1].op.op_type, optype::OpType::Rz);
+    circuit.commands.swap(0, 1);
+
+    let mut decoded = circ_reordered_opaque_parameter;
+    encoded.reassemble_inplace(&mut decoded, None).unwrap();
+    decoded.validate().unwrap();
 }
 
 /// Test the serialisation roundtrip from a tket circuit into an EncodedCircuit and back.


### PR DESCRIPTION
Fixes an issue where a temporary pytket circuit being re-inserted into a hugr panicked due to repeated parameter names when a barrier command producing said parameter got reordered.

The fix pre-allocates the parameter names produced in such barriers so there is no naming collision.