### PR TITLE
feat(qis-compiler): Add a EmulationState to handle extension passing

### DIFF
--- a/qis-compiler/README.md
+++ b/qis-compiler/README.md
@@ -13,40 +13,40 @@ from guppylang.decorator import guppy
 def main() -> None:
     # ...
 
-hugr = main.compile()
-hugr_envelope = hugr.package.to_bytes()
+package = main.compile()
 ```
 
-This can then be compiled to LLVM IR or bitcode
-using this package:
+This can then be compiled to LLVM IR or bitcode using this package:
 
 ```python
-from selene_hugr_qis_compiler import (
-    compile_to_llvm_ir,
-    compile_to_bitcode,
-)
+from selene_hugr_qis_compiler import EmulatorState
+
+state = EmulatorState.from_python(package)
 
 # Compile to LLVM IR for the host system
 # and receive it as a string
-ir = compile_to_llvm_ir(hugr_envelope)
+ir = state.compile_to_llvm_ir()
 
 # Compile to LLVM bitcode for the host system
 # and receive it as a bytes object
-bitcode = compile_to_bitcode(hugr_envelope)
+bitcode = state.compile_to_bitcode()
 ```
+
+Use `EmulatorState.from_bytes(hugr_envelope)` when loading a serialized HUGR
+package.
 
 If you wish to target a specific architecture or platform,
 you can pass the triple as an argument to the compilation functions:
 
 ```python
+state = EmulatorState.from_python(hugr.package, platform="helios")
+
 # Compile to LLVM IR for Apple Silicon
-ir_apple_silicon = compile_to_llvm_ir(
-    hugr_envelope,
+ir_apple_silicon = state.compile_to_llvm_ir(
     target_triple="aarch64-apple-darwin",
 )
 # Compile to LLVM bitcode for x86_64 MSVC
-bitcode_apple_silicon = compile_to_bitcode(
-    hugr_envelope,
+bitcode_x86_64_windows = state.compile_to_bitcode(
     target_triple="x86_64-windows-msvc",
 )
 ```

--- a/qis-compiler/pyproject.toml
+++ b/qis-compiler/pyproject.toml
@@ -40,6 +40,7 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
 version = "0.5.0" # updated by release-please
+dependencies = ["hugr~=0.18.3", "typing-extensions>=4.5"]
 
 [project.urls]
 repository = "https://github.com/quantinuum/tket2/tree/main/qis-compiler"

--- a/qis-compiler/python/selene_hugr_qis_compiler/__init__.py
+++ b/qis-compiler/python/selene_hugr_qis_compiler/__init__.py
@@ -1,11 +1,153 @@
-from .selene_hugr_qis_compiler import (
-    HugrReadError,
-    check_hugr,
-    compile_to_bitcode,
-    compile_to_llvm_ir,
-)
+"""Python interface for compiling HUGRs to Quantinuum QIS."""
 
-__all__ = ["compile_to_bitcode", "compile_to_llvm_ir", "check_hugr", "HugrReadError"]
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal, TypeAlias
+
+from hugr.hugr import Hugr
+from hugr.package import Package
+from typing_extensions import deprecated
+
+from . import selene_hugr_qis_compiler as _native
+
+Platform: TypeAlias = Literal["helios", "sol"]
+
+HugrReadError = _native.HugrReadError
+
+__all__ = [
+    "EmulatorState",
+    "HugrReadError",
+    "Platform",
+    "check_hugr",
+    "compile_to_bitcode",
+    "compile_to_llvm_ir",
+]
+
+
+@dataclass(frozen=True, init=False)
+class EmulatorState:
+    """A validated HUGR prepared once for a fixed emulator platform."""
+
+    _inner: _native.EmulatorState = field(repr=False)
+
+    def __init__(self) -> None:
+        """Prevent construction without selecting an explicit input format."""
+        raise TypeError("Use EmulatorState.from_bytes or EmulatorState.from_python")
+
+    @classmethod
+    def from_bytes(
+        cls, envelope: bytes, *, platform: Platform = "helios"
+    ) -> EmulatorState:
+        """Load, validate, and lower a serialized HUGR package."""
+        state = object.__new__(cls)
+        object.__setattr__(
+            state, "_inner", _native.EmulatorState(envelope, platform=platform)
+        )
+        return state
+
+    @classmethod
+    def from_python(
+        cls, hugr: Hugr | Package, *, platform: Platform = "helios"
+    ) -> EmulatorState:
+        """Validate and lower a Python HUGR."""
+        if isinstance(hugr, Hugr):
+            used_extensions = hugr.used_extensions().used_extensions
+            extensions = [
+                extension
+                for extension in used_extensions.extensions
+                if not _native.has_compatible_extension(
+                    str(extension.name), str(extension.version)
+                )
+            ]
+            package = Package(modules=[hugr], extensions=extensions)
+        elif isinstance(hugr, Package):
+            package = hugr
+        else:
+            raise TypeError(f"Expected a Hugr or Package, got {type(hugr)}")
+
+        return cls.from_bytes(package.to_bytes(), platform=platform)
+
+    def compile_to_llvm_ir(
+        self,
+        *,
+        opt_level: int = 2,
+        target_triple: str = "native",
+        emit_debug: bool = False,
+    ) -> str:
+        """Emit the prepared HUGR as LLVM IR."""
+        return self._inner.compile_to_llvm_ir(
+            opt_level=opt_level,
+            target_triple=target_triple,
+            emit_debug=emit_debug,
+        )
+
+    def compile_to_bitcode(
+        self,
+        *,
+        opt_level: int = 2,
+        target_triple: str = "native",
+        emit_debug: bool = False,
+    ) -> bytes:
+        """Emit the prepared HUGR as LLVM bitcode."""
+        return self._inner.compile_to_bitcode(
+            opt_level=opt_level,
+            target_triple=target_triple,
+            emit_debug=emit_debug,
+        )
+
+
+@deprecated("Use `EmulatorState.from_bytes` instead.")
+def check_hugr(pkg_bytes: bytes) -> None:
+    """Load and validate a HUGR without applying emulator lowering.
+
+    Deprecated: use :meth:`EmulatorState.from_bytes`, which also verifies that
+    the HUGR can be lowered for the selected emulator platform.
+    """
+    _native.check_hugr(pkg_bytes)
+
+
+@deprecated("Use `EmulatorState.from_bytes(...).compile_to_llvm_ir(...)` instead.")
+def compile_to_llvm_ir(
+    pkg_bytes: bytes,
+    *,
+    opt_level: int = 2,
+    target_triple: str = "native",
+    platform: Platform = "helios",
+    emit_debug: bool = False,
+) -> str:
+    """Compile serialized HUGR to LLVM IR.
+
+    Deprecated: use :meth:`EmulatorState.from_bytes` followed by
+    :meth:`EmulatorState.compile_to_llvm_ir`.
+    """
+    return EmulatorState.from_bytes(pkg_bytes, platform=platform).compile_to_llvm_ir(
+        opt_level=opt_level,
+        target_triple=target_triple,
+        emit_debug=emit_debug,
+    )
+
+
+@deprecated("Use `EmulatorState.from_bytes(...).compile_to_bitcode(...)` instead.")
+def compile_to_bitcode(
+    pkg_bytes: bytes,
+    *,
+    opt_level: int = 2,
+    target_triple: str = "native",
+    platform: Platform = "helios",
+    emit_debug: bool = False,
+) -> bytes:
+    """Compile serialized HUGR to LLVM bitcode.
+
+    Deprecated: use :meth:`EmulatorState.from_bytes` followed by
+    :meth:`EmulatorState.compile_to_bitcode`.
+    """
+    return EmulatorState.from_bytes(pkg_bytes, platform=platform).compile_to_bitcode(
+        opt_level=opt_level,
+        target_triple=target_triple,
+        emit_debug=emit_debug,
+    )
+
 
 # This is updated by our release-please workflow, triggered by this
 # annotation: x-release-please-version

--- a/qis-compiler/python/selene_hugr_qis_compiler/selene_hugr_qis_compiler.pyi
+++ b/qis-compiler/python/selene_hugr_qis_compiler/selene_hugr_qis_compiler.pyi
@@ -1,26 +1,28 @@
 from typing import Literal
 
-def compile_to_bitcode(
-    pkg_bytes: bytes,
-    *,
-    opt_level: int = 2,
-    target_triple: str = "native",
-    platform: Literal["helios", "sol"] = "helios",
-    emit_debug: bool = False,
-) -> bytes:
-    """Compile serialized HUGR to LLVM IR bitcode"""
-    ...
+class EmulatorState:
+    """A validated HUGR prepared once for a fixed emulator platform."""
 
-def compile_to_llvm_ir(
-    pkg_bytes: bytes,
-    *,
-    opt_level: int = 2,
-    target_triple: str = "native",
-    platform: Literal["helios", "sol"] = "helios",
-    emit_debug: bool = False,
-) -> str:
-    """Compile serialized HUGR to LLVM IR string"""
-    ...
+    def __init__(
+        self,
+        pkg_bytes: bytes,
+        *,
+        platform: Literal["helios", "sol"] = "helios",
+    ) -> None: ...
+    def compile_to_bitcode(
+        self,
+        *,
+        opt_level: int = 2,
+        target_triple: str = "native",
+        emit_debug: bool = False,
+    ) -> bytes: ...
+    def compile_to_llvm_ir(
+        self,
+        *,
+        opt_level: int = 2,
+        target_triple: str = "native",
+        emit_debug: bool = False,
+    ) -> str: ...
 
 def check_hugr(pkg_bytes: bytes) -> None:
     """Load serialized HUGR and validate it.
@@ -28,6 +30,14 @@ def check_hugr(pkg_bytes: bytes) -> None:
     Raises:
         HugrReadError if the HUGR is invalid.
     """
+    ...
+
+def embedded_extensions() -> list[tuple[str, str]]:
+    """Return extension names and versions available to the native loader."""
+    ...
+
+def has_compatible_extension(name: str, version: str) -> bool:
+    """Return whether the native loader can provide a compatible extension."""
     ...
 
 class HugrReadError(Exception):

--- a/qis-compiler/python/tests/test_basic_generation.py
+++ b/qis-compiler/python/tests/test_basic_generation.py
@@ -2,10 +2,19 @@ from pathlib import Path
 from typing import Literal
 
 import pytest
+from hugr import tys
+from hugr.build.dfg import Function
+from hugr.ext import Extension, OpDef, OpDefSig
+from hugr.hugr import Hugr
 from hugr.ops import CFG
 from hugr.package import Package
 from pytest_snapshot.plugin import Snapshot
-from selene_hugr_qis_compiler import HugrReadError, check_hugr, compile_to_llvm_ir
+from selene_hugr_qis_compiler import (
+    EmulatorState,
+    HugrReadError,
+)
+from selene_hugr_qis_compiler import selene_hugr_qis_compiler as _native
+from semver import Version
 from tket_exts import modifier
 
 resources_dir = Path(__file__).parent / "resources"
@@ -41,35 +50,69 @@ def contains_modifiers(hugr_envelope: bytes) -> bool:
     return False
 
 
+def extension_hugr(name: str, version: Version) -> Hugr:
+    """Build a HUGR using an operation from a specific extension version."""
+    extension = Extension(name, version)
+    op_def = extension.add_op_def(
+        OpDef("gate", OpDefSig(tys.FunctionType([tys.Qubit], [tys.Qubit])))
+    )
+
+    fn = Function("custom_op", [tys.Qubit])
+    [q] = fn.inputs()
+    [q] = fn.add_op(op_def.instantiate(), q).outputs()
+    fn.set_outputs(q)
+    return fn.hugr
+
+
 def test_check() -> None:
-    """Test the check_hugr function to ensure it can load a HUGR envelope."""
+    """Test that state construction loads and validates a HUGR envelope."""
     hugr_envelope = load("check")
-    check_hugr(hugr_envelope)  # guppy produces a valid HUGR envelope!
+    EmulatorState.from_bytes(hugr_envelope)
 
     bad_number = hugr_envelope[1:]
     with pytest.raises(HugrReadError, match="Bad magic number"):
-        check_hugr(bad_number)
+        EmulatorState.from_bytes(bad_number)
 
     bad_end = hugr_envelope[:-1]
     with pytest.raises(HugrReadError, match="Premature end of file"):
-        check_hugr(bad_end)
+        EmulatorState.from_bytes(bad_end)
 
     package = Package.from_bytes(hugr_envelope)
     hugr = package.modules[0]
     hugr.add_node(CFG([], []))
     with pytest.raises(ValueError, match="has no entry block"):
-        check_hugr(package.to_str().encode("utf-8"))
+        EmulatorState.from_bytes(package.to_str().encode("utf-8"))
 
 
-def test_unsupported_pytket_ops() -> None:
-    """Test the check_hugr function to ensure it flags unsupported pytket ops."""
-    hugr_envelope = load("unsupported_pytket_ops")
+def test_emulator_state_validates_on_construction() -> None:
     with pytest.raises(
         HugrReadError,
         match="Pytket op 'CSXdg' is not currently "
         "supported by the Selene HUGR-QIS compiler",
     ):
-        check_hugr(hugr_envelope)
+        EmulatorState.from_bytes(load("unsupported_pytket_ops"))
+
+
+def test_hugr_input_bundles_newer_extension() -> None:
+    name, version = next(
+        (name, Version.parse(version))
+        for name, version in _native.embedded_extensions()
+        if name == "logic"
+    )
+    newer_version = version.bump_patch()
+    assert not _native.has_compatible_extension(name, str(newer_version))
+
+    state = EmulatorState.from_python(extension_hugr(name, newer_version))
+
+    assert state is not None
+
+
+def test_emulator_state_accepts_package_input() -> None:
+    package = Package.from_bytes(load("check"))
+
+    ir = EmulatorState.from_python(package).compile_to_llvm_ir()
+
+    assert "define i64 @qmain" in ir
 
 
 def normalize_ir_snapshot(ir: str) -> str:
@@ -100,9 +143,8 @@ def test_llvm(
     snapshot: Snapshot, hugr_file: str, target_triple: str, platform: Platform
 ) -> None:
     hugr_envelope = load(hugr_file)
-    ir = compile_to_llvm_ir(
-        hugr_envelope, target_triple=target_triple, platform=platform, emit_debug=True
-    )
+    state = EmulatorState.from_bytes(hugr_envelope, platform=platform)
+    ir = state.compile_to_llvm_ir(target_triple=target_triple, emit_debug=True)
     ir = normalize_ir_snapshot(ir)
     snapshot.assert_match(ir, f"{hugr_file}_{target_triple}_{platform}")
 
@@ -112,7 +154,7 @@ def test_entry_args() -> None:
         RuntimeError,
         match="Entry point function must have no input parameters",
     ):
-        _ = compile_to_llvm_ir(load("entry_args"))
+        _ = EmulatorState.from_bytes(load("entry_args")).compile_to_llvm_ir()
 
 
 @pytest.mark.parametrize("platform", platforms)
@@ -120,10 +162,8 @@ def test_compile_modifiers(platform: Platform) -> None:
     hugr_envelope = load("simple_modifier")
     assert contains_modifiers(hugr_envelope)
 
-    ir = compile_to_llvm_ir(
-        hugr_envelope,
+    ir = EmulatorState.from_bytes(hugr_envelope, platform=platform).compile_to_llvm_ir(
         target_triple="x86_64-unknown-linux-gnu",
-        platform=platform,
     )
     assert "define i64 @qmain" in ir
     assert "ControlModifier" not in ir
@@ -163,5 +203,7 @@ def test_gpu(snapshot: Snapshot, target_triple: str) -> None:
     # above, using the tket_qsystem::extension::gpu entities.
     hugr_file = resources_dir / "example_gpu.hugr"
     hugr_envelope = hugr_file.read_bytes()
-    ir = compile_to_llvm_ir(hugr_envelope, target_triple=target_triple)
+    ir = EmulatorState.from_bytes(hugr_envelope).compile_to_llvm_ir(
+        target_triple=target_triple
+    )
     snapshot.assert_match(ir, f"gpu_{target_triple}")

--- a/qis-compiler/python/tests/test_qsystem_platforms.py
+++ b/qis-compiler/python/tests/test_qsystem_platforms.py
@@ -3,7 +3,7 @@ from typing import Literal
 
 import pytest
 from pytest_snapshot.plugin import Snapshot
-from selene_hugr_qis_compiler import compile_to_llvm_ir  # , HugrReadError, check_hugr
+from selene_hugr_qis_compiler import EmulatorState
 
 resources_dir = Path(__file__).parent / "resources"
 
@@ -49,8 +49,8 @@ def test_llvm_multiplatform(
     snapshot: Snapshot, hugr_file: str, target_triple: str, platform: Platform
 ) -> None:
     hugr_envelope = load(hugr_file)
-    ir = compile_to_llvm_ir(
-        hugr_envelope, target_triple=target_triple, platform=platform
+    ir = EmulatorState.from_bytes(hugr_envelope, platform=platform).compile_to_llvm_ir(
+        target_triple=target_triple
     )
     snapshot.assert_match(ir, f"{hugr_file}_{target_triple}_{platform}")
 
@@ -69,4 +69,6 @@ def test_llvm_multiplatform_todos(
     snapshot: Snapshot, hugr_file: str, target_triple: str
 ) -> None:
     hugr_envelope = load(hugr_file)
-    compile_to_llvm_ir(hugr_envelope, target_triple=target_triple, platform="sol")
+    EmulatorState.from_bytes(hugr_envelope, platform="sol").compile_to_llvm_ir(
+        target_triple=target_triple
+    )

--- a/qis-compiler/rust/emulator.rs
+++ b/qis-compiler/rust/emulator.rs
@@ -1,0 +1,62 @@
+//! Prepared emulator state for repeated LLVM emission.
+
+use anyhow::{Result, anyhow};
+use tket_qsystem::QSystemPlatform;
+
+use crate::hugr::Hugr;
+use crate::inkwell::{context::Context, module::Module};
+use crate::{CompileArgs, compile_prepared, process_hugr, validate};
+
+/// A validated HUGR prepared for emission by the Selene emulator.
+///
+/// Construction applies the platform-specific QSystem lowering passes exactly
+/// once. The resulting HUGR is then borrowed immutably by all emission calls,
+/// so producing multiple output formats does not clone or reprocess it.
+#[derive(Debug)]
+#[cfg_attr(feature = "py", pyo3::pyclass(frozen))]
+pub struct EmulatorState {
+    hugr: Hugr,
+    platform: QSystemPlatform,
+}
+
+impl EmulatorState {
+    /// Validate and prepare a HUGR for the selected emulator platform.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the HUGR is invalid, contains unsupported opaque
+    /// pytket operations, or cannot be lowered for `platform`.
+    pub fn new(mut hugr: Hugr, platform: QSystemPlatform) -> Result<Self> {
+        validate(&hugr)?;
+        process_hugr(platform, &mut hugr)?;
+        Ok(Self { hugr, platform })
+    }
+
+    /// Prepare a HUGR that has already passed [`validate`].
+    pub(crate) fn from_validated_hugr(mut hugr: Hugr, platform: QSystemPlatform) -> Result<Self> {
+        process_hugr(platform, &mut hugr)?;
+        Ok(Self { hugr, platform })
+    }
+
+    /// Return the emulator platform fixed when this state was prepared.
+    pub(crate) fn platform(&self) -> QSystemPlatform {
+        self.platform
+    }
+
+    /// Emit this prepared HUGR as an LLVM module.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `args` target a different emulator platform or LLVM
+    /// emission and optimization fail.
+    pub fn compile<'c>(&self, args: &CompileArgs, ctx: &'c Context) -> Result<Module<'c>> {
+        if self.platform != args.platform {
+            return Err(anyhow!(
+                "emulator state targets {:?}, but compilation arguments target {:?}",
+                self.platform,
+                args.platform
+            ));
+        }
+        compile_prepared(args, ctx, &self.hugr)
+    }
+}

--- a/qis-compiler/rust/lib.rs
+++ b/qis-compiler/rust/lib.rs
@@ -1,8 +1,9 @@
 //! The compiler for HUGR to QIS
 pub mod array;
 
-use anyhow::{Result, anyhow};
+use anyhow::{Context as _, Result, anyhow};
 use hugr::envelope::EnvelopeConfig;
+use hugr::extension::Version;
 use hugr::llvm::CodegenExtsBuilder;
 use hugr::llvm::custom::CodegenExtsMap;
 use hugr::llvm::emit::{EmitDebugInfo, EmitHugr, Namer, debug_info::DebugInfoContext};
@@ -49,9 +50,12 @@ pub use tket::hugr::{self, llvm::inkwell};
 pub use tket_qsystem::{self, extension::REGISTRY, llvm::futures::FuturesCodegenExtension};
 pub use utils::validate;
 
+mod emulator;
 mod gpu;
 mod selene_specific;
 mod utils;
+
+pub use emulator::EmulatorState;
 
 const LLVM_MAIN: &str = "qmain";
 const METADATA: &[(&str, &[&str])] = &[("name", &["mainlib"])];
@@ -123,6 +127,29 @@ fn process_hugr(platform: qsystem::QSystemPlatform, hugr: &mut Hugr) -> Result<(
     Ok(())
 }
 
+/// Return the extension names and versions available to the envelope loader.
+///
+/// The result is sorted so callers can compare or serialize it deterministically.
+fn embedded_extensions() -> Vec<(String, String)> {
+    let mut extensions = REGISTRY
+        .iter_all()
+        .map(|ext| (ext.name.to_string(), ext.version.to_string()))
+        .collect::<Vec<_>>();
+    extensions.sort_unstable();
+    extensions
+}
+
+/// Return whether the envelope loader can provide a compatible extension.
+///
+/// # Errors
+///
+/// Returns an error if `version` is not a valid semantic version.
+fn has_compatible_extension(name: &str, version: &str) -> Result<bool> {
+    let version = Version::parse(version)
+        .with_context(|| format!("invalid extension version: {version:?}"))?;
+    Ok(REGISTRY.get_compatible(name, &version).is_some())
+}
+
 fn codegen_extensions(platform: qsystem::QSystemPlatform) -> CodegenExtsMap<'static, Hugr> {
     use array::SeleneHeapArrayCodegen;
     let pcg = QISPreludeCodegen;
@@ -157,13 +184,12 @@ fn codegen_extensions(platform: qsystem::QSystemPlatform) -> CodegenExtsMap<'sta
 
 /// given an LLVM context and hugr, compile to an LLVM module.
 /// Returns the LLVM Module and the [Node] of the entry point.
-fn get_module_with_std_exts<'c>(
+fn get_module_from_prepared_hugr<'c>(
     args: &CompileArgs,
     context: &'c Context,
     namer: Rc<Namer>,
-    hugr: &'c mut Hugr,
+    hugr: &Hugr,
 ) -> Result<(Module<'c>, Option<DebugInfoContext<'c>>)> {
-    process_hugr(args.platform, hugr)?;
     if let Some(filename) = &args.save_hugr {
         let file = fs::File::create(PathBuf::from(filename))?;
         hugr.store(file, EnvelopeConfig::text())?;
@@ -401,6 +427,12 @@ pub fn compile<'c, 'hugr: 'c>(
     ctx: &'c Context,
     hugr: &'hugr mut Hugr,
 ) -> Result<Module<'c>> {
+    process_hugr(args.platform, hugr)?;
+    compile_prepared(args, ctx, hugr)
+}
+
+/// Compile a HUGR after the platform-specific lowering passes have run.
+fn compile_prepared<'c>(args: &CompileArgs, ctx: &'c Context, hugr: &Hugr) -> Result<Module<'c>> {
     event!(Level::DEBUG, "starting primary compilation");
     let namer = Rc::new(Namer::new("__hugr__.", true));
 
@@ -413,7 +445,7 @@ pub fn compile<'c, 'hugr: 'c>(
     let module_entry = args.entry.as_ref().map_or(LLVM_MAIN, |x| x.as_ref());
 
     // Create a new LLVM module using hugr-llvm
-    let (module, mut maybe_di_ctx) = get_module_with_std_exts(args, ctx, namer, hugr)?;
+    let (module, mut maybe_di_ctx) = get_module_from_prepared_hugr(args, ctx, namer, hugr)?;
 
     wrap_main(
         ctx,
@@ -526,11 +558,15 @@ mod exceptions {
 #[pymodule]
 mod selene_hugr_qis_compiler {
     use super::{
-        CompileArgs, Context, Hugr, PyResult, compile, get_native_target_machine, get_opt_level,
-        get_platform, get_target_machine_from_triple, public_bitcode_bytes, pyfunction,
-        read_hugr_envelope,
+        CompileArgs, Context, Hugr, PyResult, embedded_extensions as rust_extensions,
+        get_native_target_machine, get_opt_level, get_platform, get_target_machine_from_triple,
+        has_compatible_extension as rust_has_compatible_extension, public_bitcode_bytes,
+        pyfunction, read_hugr_envelope,
     };
+    use pyo3::pymethods;
 
+    #[pymodule_export]
+    use super::EmulatorState;
     #[pymodule_export]
     use super::exceptions::HugrReadError;
 
@@ -538,71 +574,102 @@ mod selene_hugr_qis_compiler {
         read_hugr_envelope(pkg_bytes).map_err(|e| HugrReadError::new_err(format!("{e:?}")))
     }
 
+    pub(crate) fn py_emulator_state(pkg_bytes: &[u8], platform: &str) -> PyResult<EmulatorState> {
+        let platform = get_platform(platform)?;
+        let hugr = py_read_envelope(pkg_bytes)?;
+        Ok(EmulatorState::from_validated_hugr(hugr, platform)?)
+    }
+
+    #[pymethods]
+    impl EmulatorState {
+        #[new]
+        #[pyo3(signature = (pkg_bytes, *, platform="helios"))]
+        fn py_new(pkg_bytes: &[u8], platform: &str) -> PyResult<Self> {
+            py_emulator_state(pkg_bytes, platform)
+        }
+
+        /// Compile the prepared HUGR to an LLVM IR string.
+        #[pyo3(signature = (*, opt_level=2, target_triple="native", emit_debug=false))]
+        pub(crate) fn compile_to_llvm_ir(
+            &self,
+            opt_level: u32,
+            target_triple: &str,
+            emit_debug: bool,
+        ) -> PyResult<String> {
+            let opt = get_opt_level(opt_level)?;
+            let target_machine = if target_triple == "native" {
+                get_native_target_machine(opt)
+            } else {
+                get_target_machine_from_triple(target_triple, opt)
+            }?;
+            let ctx = Context::create();
+            let llvm_module = self.compile(
+                &CompileArgs::new(
+                    &"hugr",
+                    &target_machine,
+                    opt,
+                    self.platform(),
+                    &ctx,
+                    emit_debug,
+                ),
+                &ctx,
+            )?;
+            Ok(llvm_module.to_string())
+        }
+
+        /// Compile the prepared HUGR to LLVM bitcode.
+        #[pyo3(signature = (*, opt_level=2, target_triple="native", emit_debug=false))]
+        pub(crate) fn compile_to_bitcode(
+            &self,
+            opt_level: u32,
+            target_triple: &str,
+            emit_debug: bool,
+        ) -> PyResult<Vec<u8>> {
+            let opt = get_opt_level(opt_level)?;
+            let target_machine = if target_triple == "native" {
+                get_native_target_machine(opt)
+            } else {
+                get_target_machine_from_triple(target_triple, opt)
+            }?;
+            let ctx = Context::create();
+            let llvm_module = self.compile(
+                &CompileArgs::new(
+                    &"hugr",
+                    &target_machine,
+                    opt,
+                    self.platform(),
+                    &ctx,
+                    emit_debug,
+                ),
+                &ctx,
+            )?;
+            Ok(public_bitcode_bytes(&llvm_module.write_bitcode_to_memory()))
+        }
+    }
+
+    /// Return extension names and versions available to the native loader.
+    #[pyfunction]
+    fn embedded_extensions() -> Vec<(String, String)> {
+        rust_extensions()
+    }
+
+    /// Return whether the native loader can provide a compatible extension.
+    #[pyfunction]
+    fn has_compatible_extension(name: &str, version: &str) -> PyResult<bool> {
+        Ok(rust_has_compatible_extension(name, version)?)
+    }
+
     /// Load serialized HUGR and validate it
     #[pyfunction]
     pub fn check_hugr(pkg_bytes: &[u8]) -> PyResult<()> {
         py_read_envelope(pkg_bytes).map(|_| ())
-    }
-
-    /// Compile HUGR package to LLVM IR string
-    #[pyfunction]
-    #[pyo3(signature = (pkg_bytes, *, opt_level=2, target_triple="native", platform="helios", emit_debug=false))]
-    pub fn compile_to_llvm_ir(
-        pkg_bytes: &[u8],
-        opt_level: u32,
-        target_triple: &str,
-        platform: &str,
-        emit_debug: bool,
-    ) -> PyResult<String> {
-        let opt = get_opt_level(opt_level)?;
-        let target_machine = if target_triple == "native" {
-            get_native_target_machine(opt)
-        } else {
-            get_target_machine_from_triple(target_triple, opt)
-        }?;
-        let platform = get_platform(platform)?;
-        let mut hugr = py_read_envelope(pkg_bytes)?;
-        let ctx = Context::create();
-        let llvm_module = compile(
-            &CompileArgs::new(&"hugr", &target_machine, opt, platform, &ctx, emit_debug),
-            &ctx,
-            &mut hugr,
-        )?;
-        Ok(llvm_module.to_string())
-    }
-
-    /// Compile HUGR package to LLVM bitcode
-    #[pyfunction]
-    #[pyo3(signature = (pkg_bytes, *, opt_level=2, target_triple="native", platform="helios", emit_debug=false))]
-    pub fn compile_to_bitcode(
-        pkg_bytes: &[u8],
-        opt_level: u32,
-        target_triple: &str,
-        platform: &str,
-        emit_debug: bool,
-    ) -> PyResult<Vec<u8>> {
-        let opt = get_opt_level(opt_level)?;
-        let target_machine = if target_triple == "native" {
-            get_native_target_machine(opt)
-        } else {
-            get_target_machine_from_triple(target_triple, opt)
-        }?;
-        let platform = get_platform(platform)?;
-        let mut hugr = py_read_envelope(pkg_bytes)?;
-        let ctx = Context::create();
-        let llvm_module = compile(
-            &CompileArgs::new(&"hugr", &target_machine, opt, platform, &ctx, emit_debug),
-            &ctx,
-            &mut hugr,
-        )?;
-        Ok(public_bitcode_bytes(&llvm_module.write_bitcode_to_memory()))
     }
 }
 
 #[cfg(test)]
 mod tests {
     #[cfg(feature = "py")]
-    use super::selene_hugr_qis_compiler::compile_to_bitcode;
+    use super::selene_hugr_qis_compiler::py_emulator_state;
     use std::{
         fs,
         time::{SystemTime, UNIX_EPOCH},
@@ -636,7 +703,10 @@ mod tests {
     #[test]
     fn test_compile_to_bitcode_returns_file_safe_public_bytes() {
         let hugr = include_bytes!("../python/tests/resources/check.hugr");
-        let bitcode = compile_to_bitcode(hugr, 2, "native", "helios", false)
+        let state = py_emulator_state(hugr, "helios")
+            .expect("preparing fixture for the emulator should work");
+        let bitcode = state
+            .compile_to_bitcode(2, "native", false)
             .expect("compiling fixture to bitcode should work");
 
         let module =
@@ -657,7 +727,10 @@ mod tests {
     #[test]
     fn test_compile_or_chain_program() {
         let hugr = include_bytes!("../python/tests/resources/slp_or_chain.hugr");
-        let bitcode = compile_to_bitcode(hugr, 2, "native", "helios", false)
+        let state = py_emulator_state(hugr, "helios")
+            .expect("preparing fixture for the emulator should work");
+        let bitcode = state
+            .compile_to_bitcode(2, "native", false)
             .expect("compiling the or-chain fixture to bitcode should work");
 
         parse_bitcode_as_file(&bitcode).expect("or-chain bitcode should parse from file");

--- a/uv.lock
+++ b/uv.lock
@@ -2780,6 +2780,10 @@ wheels = [
 name = "selene-hugr-qis-compiler"
 version = "0.5.0"
 source = { editable = "qis-compiler" }
+dependencies = [
+    { name = "hugr" },
+    { name = "typing-extensions" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -2792,6 +2796,10 @@ dev = [
 ]
 
 [package.metadata]
+requires-dist = [
+    { name = "hugr", specifier = "~=0.18.3" },
+    { name = "typing-extensions", specifier = ">=4.5" },
+]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Closes #1983, fixes #1981.

Adds a `EmulationState` in `qis-compiler` similar to `tket-py`'s `CompilationState`.

This replaces the old interfaces that took raw `bytes` with a python class definition that knows how to encode python hugrs, and can decide which extensions need to be serialized into the wire format.

Like with #1976, this will ensure that updates to the `std` extension set in `hugr-py` do not cause resolution errors when those hugrs get emulated.

I updated the example in `README.md`. Instead of
```py
ir_apple_silicon = compile_to_llvm_ir(
    hugr.to_bytes(),
    platform="helios",
    target_triple="aarch64-apple-darwin",
)
```
we now write
```py
state = EmulatorState.from_python(hugr.package, platform="helios")
ir_apple_silicon = state.compile_to_llvm_ir(
    target_triple="aarch64-apple-darwin",
)
```

The old functions have been deprecated.