### PR TITLE
fix: reuse generated operation functions

### DIFF
--- a/tket-qsystem/src/extension/qsystem/barrier.rs
+++ b/tket-qsystem/src/extension/qsystem/barrier.rs
@@ -139,4 +139,28 @@ mod test {
             }
         }
     }
+
+    #[test]
+    fn repeated_barriers_share_wrapped_function() {
+        let mut b =
+            DFGBuilder::new(hugr::types::Signature::new_endo(vec![qb_t(), qb_t()])).unwrap();
+        let first = b.add_barrier(b.input_wires()).unwrap();
+        let second = b.add_barrier(first.outputs()).unwrap();
+        let mut h = b.finish_hugr_with_outputs(second.outputs()).unwrap();
+
+        lower_tk2_ops(&mut h, Preserve::Public, QSystemPlatform::Helios).unwrap();
+        h.validate().unwrap();
+
+        let wrapped_function = h
+            .children(h.module_root())
+            .filter(|&node| {
+                h.get_optype(node).as_func_defn().is_some_and(|op| {
+                    op.func_name()
+                        .contains(wrapped_barrier::WRAPPED_BARRIER_NAME.as_str())
+                })
+            })
+            .exactly_one()
+            .expect("identical barriers should share one wrapped function");
+        assert_eq!(h.output_neighbours(wrapped_function).count(), 2);
+    }
 }

--- a/tket-qsystem/src/extension/qsystem/barrier.rs
+++ b/tket-qsystem/src/extension/qsystem/barrier.rs
@@ -160,6 +160,7 @@ mod test {
                 })
             })
             .exactly_one()
+            .ok()
             .expect("identical barriers should share one wrapped function");
         assert_eq!(h.output_neighbours(wrapped_function).count(), 2);
     }

--- a/tket/src/passes/replace_types.rs
+++ b/tket/src/passes/replace_types.rs
@@ -24,8 +24,7 @@ use hugr_core::ops::{
     ExtensionOp, Input, LoadConstant, LoadFunction, OpTrait, OpType, Output, Tag, TailLoop, Value,
 };
 use hugr_core::types::{
-    ConstTypeError, CustomType, PolyFuncType, Signature, Transformable, Type, TypeArg, TypeRow,
-    TypeTransformer,
+    ConstTypeError, CustomType, Signature, Transformable, Type, TypeArg, TypeRow, TypeTransformer,
 };
 use hugr_core::{Direction, Hugr, HugrView, Node, PortIndex, Visibility, Wire};
 
@@ -66,11 +65,6 @@ pub enum NodeTemplate {
     /// Other children of the Hugr reachable from the entrypoint will also be inserted
     /// according to the specified linking policy.
     LinkedHugr(Box<Hugr>, NameLinkingPolicy),
-    /// Calls a function that is already defined in the HUGR being transformed.
-    ///
-    /// Unlike [`Self::call_to_function`], this does not link a fresh copy of the
-    /// function into the HUGR for each replacement.
-    CallFunction(FuncID<true>, Call),
 }
 
 impl NodeTemplate {
@@ -121,18 +115,6 @@ impl NodeTemplate {
         ))
     }
 
-    /// Creates a template that calls an existing function in the HUGR being transformed.
-    pub fn call_existing_function(
-        function: FuncID<true>,
-        func_sig: PolyFuncType,
-        type_args: &[TypeArg],
-    ) -> Result<Self, SignatureError> {
-        Ok(Self::CallFunction(
-            function,
-            Call::try_new(func_sig, type_args)?,
-        ))
-    }
-
     /// Adds this instance to the specified [`HugrMut`] as a new node or subtree under a
     /// given parent, returning the unique new child (of that parent) thus created
     ///
@@ -150,12 +132,6 @@ impl NodeTemplate {
     ) -> Result<Node, BuildError> {
         match self {
             NodeTemplate::SingleOp(op_type) => Ok(hugr.add_node_with_parent(parent, op_type)),
-            NodeTemplate::CallFunction(function, call) => {
-                let static_inport = call.called_function_port();
-                let call = hugr.add_node_with_parent(parent, call);
-                hugr.connect(function.node(), 0, call, static_inport);
-                Ok(call)
-            }
             NodeTemplate::CompoundOp(new_h) => {
                 Ok(hugr.insert_hugr(parent, *new_h).inserted_entrypoint)
             }
@@ -173,9 +149,6 @@ impl NodeTemplate {
     ) -> Result<BuildHandle<DataflowOpID>, BuildError> {
         match self {
             NodeTemplate::SingleOp(opty) => dfb.add_dataflow_op(opty, inputs),
-            NodeTemplate::CallFunction(function, call) => {
-                dfb.call(&function, &call.type_args, inputs)
-            }
             NodeTemplate::CompoundOp(h) => dfb.add_hugr_with_wires(*h, inputs),
             NodeTemplate::LinkedHugr(h, pol) => dfb.add_link_hugr_with_wires(*h, &pol, inputs),
         }
@@ -204,10 +177,6 @@ impl NodeTemplate {
                     }));
                 }
                 (op_type, None, None)
-            }
-            NodeTemplate::CallFunction(function, call) => {
-                let static_inport = call.called_function_port();
-                (call.into(), Some(function.node()), Some(static_inport))
             }
             NodeTemplate::CompoundOp(new_h) => {
                 let root = new_h.entrypoint_optype();
@@ -287,11 +256,11 @@ impl NodeTemplate {
         outputs: &TypeRow,
     ) -> Result<(), Option<Signature>> {
         let sig = match self {
-            NodeTemplate::CallFunction(_, call) => Some(Cow::Borrowed(&call.instantiation)),
-            NodeTemplate::SingleOp(op_type) => op_type.dataflow_signature(),
-            NodeTemplate::CompoundOp(hugr) => hugr.entrypoint_optype().dataflow_signature(),
-            NodeTemplate::LinkedHugr(hugr, _) => hugr.entrypoint_optype().dataflow_signature(),
-        };
+            NodeTemplate::SingleOp(op_type) => op_type,
+            NodeTemplate::CompoundOp(hugr) => hugr.entrypoint_optype(),
+            NodeTemplate::LinkedHugr(hugr, _) => hugr.entrypoint_optype(),
+        }
+        .dataflow_signature();
         if sig.as_deref().map(Signature::io) == Some((inputs, outputs)) {
             Ok(())
         } else {

--- a/tket/src/passes/replace_types.rs
+++ b/tket/src/passes/replace_types.rs
@@ -24,7 +24,8 @@ use hugr_core::ops::{
     ExtensionOp, Input, LoadConstant, LoadFunction, OpTrait, OpType, Output, Tag, TailLoop, Value,
 };
 use hugr_core::types::{
-    ConstTypeError, CustomType, Signature, Transformable, Type, TypeArg, TypeRow, TypeTransformer,
+    ConstTypeError, CustomType, PolyFuncType, Signature, Transformable, Type, TypeArg, TypeRow,
+    TypeTransformer,
 };
 use hugr_core::{Direction, Hugr, HugrView, Node, PortIndex, Visibility, Wire};
 
@@ -65,6 +66,11 @@ pub enum NodeTemplate {
     /// Other children of the Hugr reachable from the entrypoint will also be inserted
     /// according to the specified linking policy.
     LinkedHugr(Box<Hugr>, NameLinkingPolicy),
+    /// Calls a function that is already defined in the HUGR being transformed.
+    ///
+    /// Unlike [`Self::call_to_function`], this does not link a fresh copy of the
+    /// function into the HUGR for each replacement.
+    CallFunction(FuncID<true>, Call),
 }
 
 impl NodeTemplate {
@@ -115,6 +121,18 @@ impl NodeTemplate {
         ))
     }
 
+    /// Creates a template that calls an existing function in the HUGR being transformed.
+    pub fn call_existing_function(
+        function: FuncID<true>,
+        func_sig: PolyFuncType,
+        type_args: &[TypeArg],
+    ) -> Result<Self, SignatureError> {
+        Ok(Self::CallFunction(
+            function,
+            Call::try_new(func_sig, type_args)?,
+        ))
+    }
+
     /// Adds this instance to the specified [`HugrMut`] as a new node or subtree under a
     /// given parent, returning the unique new child (of that parent) thus created
     ///
@@ -132,6 +150,12 @@ impl NodeTemplate {
     ) -> Result<Node, BuildError> {
         match self {
             NodeTemplate::SingleOp(op_type) => Ok(hugr.add_node_with_parent(parent, op_type)),
+            NodeTemplate::CallFunction(function, call) => {
+                let static_inport = call.called_function_port();
+                let call = hugr.add_node_with_parent(parent, call);
+                hugr.connect(function.node(), 0, call, static_inport);
+                Ok(call)
+            }
             NodeTemplate::CompoundOp(new_h) => {
                 Ok(hugr.insert_hugr(parent, *new_h).inserted_entrypoint)
             }
@@ -149,6 +173,9 @@ impl NodeTemplate {
     ) -> Result<BuildHandle<DataflowOpID>, BuildError> {
         match self {
             NodeTemplate::SingleOp(opty) => dfb.add_dataflow_op(opty, inputs),
+            NodeTemplate::CallFunction(function, call) => {
+                dfb.call(&function, &call.type_args, inputs)
+            }
             NodeTemplate::CompoundOp(h) => dfb.add_hugr_with_wires(*h, inputs),
             NodeTemplate::LinkedHugr(h, pol) => dfb.add_link_hugr_with_wires(*h, &pol, inputs),
         }
@@ -177,6 +204,10 @@ impl NodeTemplate {
                     }));
                 }
                 (op_type, None, None)
+            }
+            NodeTemplate::CallFunction(function, call) => {
+                let static_inport = call.called_function_port();
+                (call.into(), Some(function.node()), Some(static_inport))
             }
             NodeTemplate::CompoundOp(new_h) => {
                 let root = new_h.entrypoint_optype();
@@ -256,11 +287,11 @@ impl NodeTemplate {
         outputs: &TypeRow,
     ) -> Result<(), Option<Signature>> {
         let sig = match self {
-            NodeTemplate::SingleOp(op_type) => op_type,
-            NodeTemplate::CompoundOp(hugr) => hugr.entrypoint_optype(),
-            NodeTemplate::LinkedHugr(hugr, _) => hugr.entrypoint_optype(),
-        }
-        .dataflow_signature();
+            NodeTemplate::CallFunction(_, call) => Some(Cow::Borrowed(&call.instantiation)),
+            NodeTemplate::SingleOp(op_type) => op_type.dataflow_signature(),
+            NodeTemplate::CompoundOp(hugr) => hugr.entrypoint_optype().dataflow_signature(),
+            NodeTemplate::LinkedHugr(hugr, _) => hugr.entrypoint_optype().dataflow_signature(),
+        };
         if sig.as_deref().map(Signature::io) == Some((inputs, outputs)) {
             Ok(())
         } else {

--- a/tket/src/passes/utils/unpack_container.rs
+++ b/tket/src/passes/utils/unpack_container.rs
@@ -577,14 +577,22 @@ mod tests {
     fn repeated_ops_share_lowering_functions() -> Result<(), BuildError> {
         let factory = UnpackContainerBuilder::new(TypeUnpacker::for_qubits());
         let option_qb_type = Type::from(option_type([qb_t()]));
-        let mut builder = FunctionBuilder::new("main", Signature::new_endo([option_qb_type]))?;
+        let option_usize_type = Type::from(option_type([usize_t()]));
+        let mut builder = FunctionBuilder::new(
+            "main",
+            Signature::new_endo([option_qb_type, option_usize_type]),
+        )?;
 
-        let input = builder.input().out_wire(0);
-        let unwrapped = factory.unpack_option(&mut builder, input, &qb_t())?;
+        let qb_input = builder.input().out_wire(0);
+        let unwrapped = factory.unpack_option(&mut builder, qb_input, &qb_t())?;
         let wrapped = factory.repack_option(&mut builder, unwrapped, &qb_t())?;
         let unwrapped = factory.unpack_option(&mut builder, wrapped, &qb_t())?;
-        let wrapped = factory.repack_option(&mut builder, unwrapped, &qb_t())?;
-        let mut hugr = builder.finish_hugr_with_outputs([wrapped])?;
+        let qb_output = factory.repack_option(&mut builder, unwrapped, &qb_t())?;
+
+        let usize_input = builder.input().out_wire(1);
+        let unwrapped = factory.unpack_option(&mut builder, usize_input, &usize_t())?;
+        let usize_output = factory.repack_option(&mut builder, unwrapped, &usize_t())?;
+        let mut hugr = builder.finish_hugr_with_outputs([qb_output, usize_output])?;
 
         let mut lowerer = ReplaceTypes::new_empty();
         factory
@@ -601,12 +609,13 @@ mod tests {
                     .is_some_and(|op| op.func_name() != "main")
             })
             .collect::<Vec<_>>();
-        assert_eq!(lowering_functions.len(), 2);
-        assert!(
-            lowering_functions
-                .iter()
-                .all(|&function| hugr.output_neighbours(function).count() == 2)
-        );
+        assert_eq!(lowering_functions.len(), 4);
+        let mut use_counts = lowering_functions
+            .iter()
+            .map(|&function| hugr.output_neighbours(function).count())
+            .collect::<Vec<_>>();
+        use_counts.sort_unstable();
+        assert_eq!(use_counts, [1, 1, 2, 2]);
         Ok(())
     }
 

--- a/tket/src/passes/utils/unpack_container.rs
+++ b/tket/src/passes/utils/unpack_container.rs
@@ -541,12 +541,14 @@ mod tests {
     use super::*;
     use hugr::{
         HugrView,
-        builder::{DFGBuilder, DataflowHugr as _},
+        builder::{DFGBuilder, DataflowHugr as _, FunctionBuilder},
         extension::prelude::{bool_t, option_type, qb_t, usize_t},
         std_extensions::collections::array::array_type,
         types::Signature,
     };
     use rstest::rstest;
+
+    use crate::passes::{ComposablePass, ReplaceTypes};
 
     #[test]
     fn test_container_factory_creation() {
@@ -568,6 +570,43 @@ mod tests {
 
         let hugr = builder.finish_hugr_with_outputs([wrapped])?;
         assert!(hugr.validate().is_ok());
+        Ok(())
+    }
+
+    #[test]
+    fn repeated_ops_share_lowering_functions() -> Result<(), BuildError> {
+        let factory = UnpackContainerBuilder::new(TypeUnpacker::for_qubits());
+        let option_qb_type = Type::from(option_type([qb_t()]));
+        let mut builder = FunctionBuilder::new("main", Signature::new_endo([option_qb_type]))?;
+
+        let input = builder.input().out_wire(0);
+        let unwrapped = factory.unpack_option(&mut builder, input, &qb_t())?;
+        let wrapped = factory.repack_option(&mut builder, unwrapped, &qb_t())?;
+        let unwrapped = factory.unpack_option(&mut builder, wrapped, &qb_t())?;
+        let wrapped = factory.repack_option(&mut builder, unwrapped, &qb_t())?;
+        let mut hugr = builder.finish_hugr_with_outputs([wrapped])?;
+
+        let mut lowerer = ReplaceTypes::new_empty();
+        factory
+            .into_function_map()
+            .register_operation_replacements(&mut hugr, &mut lowerer);
+        lowerer.run(&mut hugr).unwrap();
+        hugr.validate().unwrap();
+
+        let lowering_functions = hugr
+            .children(hugr.module_root())
+            .filter(|&node| {
+                hugr.get_optype(node)
+                    .as_func_defn()
+                    .is_some_and(|op| op.func_name() != "main")
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(lowering_functions.len(), 2);
+        assert!(
+            lowering_functions
+                .iter()
+                .all(|&function| hugr.output_neighbours(function).count() == 2)
+        );
         Ok(())
     }
 

--- a/tket/src/passes/utils/unpack_container/op_function_map.rs
+++ b/tket/src/passes/utils/unpack_container/op_function_map.rs
@@ -3,14 +3,15 @@
 use crate::passes::monomorphize::mangle_name;
 use crate::passes::{ReplaceTypes, replace_types::NodeTemplate};
 use hugr::HugrView;
-use hugr::ops::handle::FuncID;
 use hugr::{
     Hugr, Node, Wire,
     builder::{BuildError, DataflowHugr, FunctionBuilder},
     hugr::hugrmut::HugrMut,
-    ops::{DataflowOpTrait, ExtensionOp},
+    ops::{DataflowOpTrait, ExtensionOp, OpType},
     types::TypeArg,
 };
+use hugr_core::Visibility;
+use hugr_core::hugr::internal::HugrMutInternals;
 use indexmap::IndexMap;
 use std::{cell::RefCell, ops::Deref};
 
@@ -115,25 +116,26 @@ impl OpFunctionMap {
     /// corresponding function definitions.
     pub fn register_operation_replacements(
         self,
-        hugr: &mut impl HugrMut<Node = Node>,
+        _hugr: &mut impl HugrMut<Node = Node>,
         lowerer: &mut ReplaceTypes,
     ) {
         for (op, func_def) in self.into_function_iter() {
-            let func_sig = func_def
-                .entrypoint_optype()
-                .as_func_defn()
-                .expect("OpFunctionMap entries must be function definitions")
-                .signature()
-                .clone();
-            let function = FuncID::<true>::from(
-                hugr.insert_hugr(hugr.module_root(), func_def)
-                    .inserted_entrypoint,
-            );
-            let template = NodeTemplate::call_existing_function(function, func_sig, &[])
-                .expect("OpFunctionMap entries are monomorphic");
-            lowerer.set_replace_op(&op, template);
+            lowerer.set_replace_op(&op, func_as_node_template(func_def));
         }
     }
+}
+
+/// Given a HUGR with a function definition as entrypoint, constructs a
+/// [`NodeTemplate::LinkedHugr`] that produces a call to the function.
+fn func_as_node_template(mut func_def: Hugr) -> NodeTemplate {
+    let entrypoint = func_def.entrypoint();
+    let OpType::FuncDefn(func) = func_def.optype_mut(entrypoint) else {
+        panic!("OpFunctionMap entries must be function definitions");
+    };
+    *func.visibility_mut() = Visibility::Public;
+
+    NodeTemplate::call_to_function(func_def, &[])
+        .expect("OpFunctionMap entries must be monomorphic function definitions")
 }
 
 impl Default for OpFunctionMap {

--- a/tket/src/passes/utils/unpack_container/op_function_map.rs
+++ b/tket/src/passes/utils/unpack_container/op_function_map.rs
@@ -3,9 +3,7 @@
 use crate::passes::monomorphize::mangle_name;
 use crate::passes::{ReplaceTypes, replace_types::NodeTemplate};
 use hugr::HugrView;
-use hugr::builder::{Container, Dataflow, HugrBuilder};
-use hugr::hugr::linking::OnMultiDefn;
-use hugr::ops::handle::{FuncID, NodeHandle};
+use hugr::ops::handle::FuncID;
 use hugr::{
     Hugr, Node, Wire,
     builder::{BuildError, DataflowHugr, FunctionBuilder},
@@ -13,8 +11,6 @@ use hugr::{
     ops::{DataflowOpTrait, ExtensionOp},
     types::TypeArg,
 };
-use hugr_core::Visibility;
-use hugr_core::hugr::linking::NameLinkingPolicy;
 use indexmap::IndexMap;
 use std::{cell::RefCell, ops::Deref};
 
@@ -119,12 +115,23 @@ impl OpFunctionMap {
     /// corresponding function definitions.
     pub fn register_operation_replacements(
         self,
-        _hugr: &mut impl HugrMut<Node = Node>,
+        hugr: &mut impl HugrMut<Node = Node>,
         lowerer: &mut ReplaceTypes,
     ) {
-        // Use the centralized cache for all operation replacements
         for (op, func_def) in self.into_function_iter() {
-            lowerer.set_replace_op(&op, func_as_node_template(func_def));
+            let func_sig = func_def
+                .entrypoint_optype()
+                .as_func_defn()
+                .expect("OpFunctionMap entries must be function definitions")
+                .signature()
+                .clone();
+            let function = FuncID::<true>::from(
+                hugr.insert_hugr(hugr.module_root(), func_def)
+                    .inserted_entrypoint,
+            );
+            let template = NodeTemplate::call_existing_function(function, func_sig, &[])
+                .expect("OpFunctionMap entries are monomorphic");
+            lowerer.set_replace_op(&op, template);
         }
     }
 }
@@ -133,31 +140,4 @@ impl Default for OpFunctionMap {
     fn default() -> Self {
         Self::new()
     }
-}
-
-/// Given a hugr with a function definition as entrypoint, constructs a
-/// [`NodeTemplate::LinkedHugr`] that produces a call to the function.
-//
-// TODO: Use [`NodeTemplate::call_to_function`] once it gets released in `hugr 0.25.6`.
-fn func_as_node_template(func_def: Hugr) -> NodeTemplate {
-    // Create a replacement hugr for the op nodes: Add a `call` node in the `func_def` hugr and set it as entrypoint.
-    let func_signature = func_def.inner_function_type().unwrap().into_owned();
-
-    // Build a new hugr and insert the function definition into it
-    let mut b = FunctionBuilder::new_vis("", func_signature, Visibility::Private).unwrap();
-    let func_id = FuncID::<true>::from(
-        b.module_root_builder()
-            .add_hugr(func_def)
-            .inserted_entrypoint,
-    );
-
-    // Build a call to the function in the new separate function.
-    let call = b.call(&func_id, &[], b.input_wires()).unwrap();
-    let mut call_hugr = b.finish_hugr_with_outputs(call.outputs()).unwrap();
-    call_hugr.set_entrypoint(call.node());
-
-    NodeTemplate::LinkedHugr(
-        Box::new(call_hugr),
-        NameLinkingPolicy::default().on_multiple_defn(OnMultiDefn::UseTarget),
-    )
 }

--- a/tket/src/passes/utils/unpack_container/op_function_map.rs
+++ b/tket/src/passes/utils/unpack_container/op_function_map.rs
@@ -76,7 +76,16 @@ impl OpFunctionMap {
         if self.map.borrow().contains_key(&key) {
             return Ok(());
         }
-        let name = mangle_name(op.def().name(), mangle_args);
+        // Definitions are made public while name linking deduplicates them, so
+        // the symbol must distinguish every cached operation instance. Keep
+        // caller-selected arguments for readability, and append the complete
+        // operation arguments to guarantee uniqueness.
+        let name_args = mangle_args
+            .iter()
+            .chain(op.args())
+            .cloned()
+            .collect::<Vec<_>>();
+        let name = mangle_name(op.def().name(), name_args);
         let sig = op.signature().deref().clone();
         let mut func_b = FunctionBuilder::new(name, sig)?;
         // insert None as a placeholder to avoid cyclic recursion in func_builder call


### PR DESCRIPTION
## Summary

- make cached `OpFunctionMap` definitions public while HUGR linking runs
- reuse `NodeTemplate::call_to_function` so `OnMultiDefn::UseTarget` coalesces repeated definitions
- rely on the existing qsystem hiding phase to restore generated helpers to private visibility
- add generic and wrapped-barrier regressions asserting repeated operations share one definition

## Root cause

`OpFunctionMap` cached one generated HUGR per operation shape, but its replacement template embedded a private function HUGR at every call site. Name linking only coalesces public definitions, so `OnMultiDefn::UseTarget` had no effect and repeated barriers produced thousands of equivalent wrapper functions. Wide wrappers then amplified LLVM IPSCCP memory use.

The fix belongs in `func_as_node_template`: cached helpers are now linker-visible when passed through the existing `call_to_function` path. `QSystemRebasePass` already records pre-existing public functions and hides newly introduced helpers after lowering, so the final HUGR retains private linkage without adding a parallel call-template mechanism.

## Validation

- `cargo check -p tket -p tket-qsystem`
- `cargo test -p tket --lib` (604 passed, 2 ignored)
- `cargo test -p tket-qsystem --lib` (167 passed, 1 ignored)
- `just check`: formatting, Ruff, mypy, Cargo check/docs, and pg-libs tests passed; the full local gate remains blocked by unrelated existing nightly Clippy findings and macOS hugrenv `@rpath` resolution in aggregate nextest/Python discovery
- `git diff --check origin/main...HEAD`
